### PR TITLE
Update langchain integration docs to fix deprecations

### DIFF
--- a/docs/docs/integrations/langchain.md
+++ b/docs/docs/integrations/langchain.md
@@ -8,10 +8,10 @@ Tavily API can now empower your Langchain application with real time online info
 ### How to use Tavily API with Langchain
 ```python
 import os
-from langchain.utilities.tavily_search import TavilySearchAPIWrapper
-from langchain.agents import initialize_agent, AgentType
-from langchain_community.chat_models import ChatOpenAI
-from langchain.tools.tavily_search import TavilySearchResults
+from langchain_community.utilities.tavily_search import TavilySearchAPIWrapper
+from langchain.agents.agent_toolkits import create_conversational_retrieval_agent
+from langchain_openai import ChatOpenAI
+from langchain_community.tools.tavily_search.tool import TavilySearchResults
 
 # set up API key
 os.environ["TAVILY_API_KEY"] = "..."
@@ -22,17 +22,18 @@ search = TavilySearchAPIWrapper()
 tavily_tool = TavilySearchResults(api_wrapper=search)
 
 # initialize the agent
-agent_chain = initialize_agent(
-    [tavily_tool],
+agent_chain = create_conversational_retrieval_agent(
     llm,
-    agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,
+    [tavily_tool],
     verbose=True,
 )
 
 # run the agent
-agent_chain.run(
-    "What happened in the latest burning man floods?",
+result = agent_chain.invoke(
+    "What happened in the latest burning man floods?"
 )
+
+print(result["output"])
 ```
 
 #### Result:


### PR DESCRIPTION
Purely a docs fix.
Fixes these three deprecation warnings from the existing langchain example code:

```
demo.py:10: LangChainDeprecationWarning: The class `ChatOpenAI` was deprecated in LangChain 0.0.10 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-openai package and should be used instead. To use it run `pip install -U :class:`~langchain-openai` and import as `from :class:`~langchain_openai import ChatOpenAI``.
  llm = ChatOpenAI(model_name="gpt-4", temperature=0.7)
demo.py:15: LangChainDeprecationWarning: The function `initialize_agent` was deprecated in LangChain 0.1.0 and will be removed in 1.0. Use :meth:`~Use new agent constructor methods like create_react_agent, create_json_agent, create_structured_chat_agent, etc.` instead.
  agent_chain = initialize_agent(
demo.py:27: LangChainDeprecationWarning: The method `Chain.run` was deprecated in langchain 0.1.0 and will be removed in 1.0. Use :meth:`~invoke` instead.
  agent_chain.run(
```

The two imports were easy to fix.  The `initialize_agent` call less so, as I didn't know which of the new constructor functions to use, and none of the suggested three turned out to be correct.  Eventually realized that the old call was returning an `AgentExecutor` and found the function that creates that.

This was tested against these versions:

```
langchain==0.3.4
langchain-community==0.3.3
langchain-core==0.3.13
langchain-openai==0.2.4
tavily-python==0.5.0
```
