### PR TITLE
Adding verify argument for requests

### DIFF
--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -9,11 +9,11 @@ from .errors import UsageLimitExceededError, InvalidAPIKeyError, MissingAPIKeyEr
 from .config import AllowedCategory
 
 class TavilyClient:
-    """
+    """ 
     Tavily API client class.
     """
 
-    def __init__(self, api_key: Optional[str] = None, proxies: Optional[dict[str, str]] = None, api_base_url: Optional[str] = None):
+    def __init__(self, api_key: Optional[str] = None, proxies: Optional[dict[str, str]] = None, api_base_url: Optional[str] = None, verify: bool = True):
         if api_key is None:
             api_key = os.getenv("TAVILY_API_KEY")
 
@@ -35,6 +35,7 @@ class TavilyClient:
             "Authorization": f"Bearer {self.api_key}",
             "X-Client-Source": "tavily-python"
         }
+        self.verify = verify
 
     def _search(self,
                 query: str,
@@ -87,7 +88,7 @@ class TavilyClient:
         timeout = min(timeout, 120)
 
         try:
-            response = requests.post(self.base_url + "/search", data=json.dumps(data), headers=self.headers, timeout=timeout, proxies=self.proxies)
+            response = requests.post(self.base_url + "/search", data=json.dumps(data), headers=self.headers, timeout=timeout, proxies=self.proxies , verify=self.verify)
         except requests.exceptions.Timeout:
             raise TimeoutError(timeout)
 


### PR DESCRIPTION
verify argument should be passed at the time of calling Tavily search , for users with stringent SSL filters its failing to hit https://api.tavily.com/ leading to SSL cert errors.

Keeping default verify as True 