### PR TITLE
feat(async-client): add session pooling for connection reuse TAV-4105

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .env
 venv/
 test_local.py
+test_local_suite.py

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='tavily-python',
-    version='0.7.20',
+    version='0.7.21',
     url='https://github.com/tavily-ai/tavily-python',
     author='Tavily AI',
     author_email='support@tavily.com',

--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import os
-from typing import Literal, Sequence, Optional, List, Union, AsyncGenerator, Awaitable
+from typing import Literal, Sequence, Optional, List, Union, AsyncGenerator
 
 import httpx
 
@@ -14,12 +14,15 @@ class AsyncTavilyClient:
     Async Tavily API client class.
     """
 
-    def __init__(self, api_key: Optional[str] = None,
-                 company_info_tags: Sequence[str] = ("news", "general", "finance"),
-                 proxies: Optional[dict[str, str]] = None,
-                 api_base_url: Optional[str] = None,
-                 client_source: Optional[str] = None,
-                 project_id: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        company_info_tags: Sequence[str] = ("news", "general", "finance"),
+        proxies: Optional[dict[str, str]] = None,
+        api_base_url: Optional[str] = None,
+        client_source: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ):
         if api_key is None:
             api_key = os.getenv("TAVILY_API_KEY")
 
@@ -32,7 +35,6 @@ class AsyncTavilyClient:
             "http://": proxies.get("http", os.getenv("TAVILY_HTTP_PROXY")),
             "https://": proxies.get("https", os.getenv("TAVILY_HTTPS_PROXY")),
         }
-
         mapped_proxies = {key: value for key, value in mapped_proxies.items() if value}
 
         proxy_mounts = (
@@ -43,44 +45,82 @@ class AsyncTavilyClient:
 
         tavily_project = project_id or os.getenv("TAVILY_PROJECT")
 
-        self._api_base_url = api_base_url or "https://api.tavily.com"
-        
-        self._client_creator = lambda: httpx.AsyncClient(
+        self._client = httpx.AsyncClient(
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {api_key}",
                 "X-Client-Source": client_source or "tavily-python",
                 **({"X-Project-ID": tavily_project} if tavily_project else {})
             },
-            base_url=self._api_base_url,
-            mounts=proxy_mounts
+            base_url=api_base_url or "https://api.tavily.com",
+            mounts=proxy_mounts,
         )
         self._company_info_tags = company_info_tags
 
-    async def _search(
-            self,
-            query: str,
-            search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = None,
-            topic: Literal["general", "news", "finance"] = None,
-            time_range: Literal["day", "week", "month", "year"] = None,
-            start_date: str = None,
-            end_date: str = None,
-            days: int = None,
-            max_results: int = None,
-            include_domains: Sequence[str] = None,
-            exclude_domains: Sequence[str] = None,
-            include_answer: Union[bool, Literal["basic", "advanced"]] = None,
-            include_raw_content: Union[bool, Literal["markdown", "text"]] = None,
-            include_images: bool = None,
-            timeout: float = 60,
-            country: str = None,
-            auto_parameters: bool = None,
-            include_favicon: bool = None,
-            include_usage: bool = None,
-            **kwargs,
+    async def close(self) -> None:
+        """Close the client and release connection pool resources."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncTavilyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    def _handle_error_response(self, response: httpx.Response) -> None:
+        """Handle non-200 HTTP responses by raising appropriate exceptions."""
+        detail = ""
+        try:
+            detail = response.json().get("detail", {}).get("error", None)
+        except Exception:
+            pass
+
+        status = response.status_code
+        if status == 429:
+            raise UsageLimitExceededError(detail)
+        if status in (403, 432, 433):
+            raise ForbiddenError(detail)
+        if status == 401:
+            raise InvalidAPIKeyError(detail)
+        if status == 400:
+            raise BadRequestError(detail)
+        response.raise_for_status()
+
+    async def _post(self, endpoint: str, data: dict, timeout: float) -> dict:
+        """Make a POST request and handle response/errors."""
+        try:
+            response = await self._client.post(endpoint, content=json.dumps(data), timeout=timeout)
+        except httpx.TimeoutException:
+            raise TimeoutError(timeout)
+
+        if response.status_code == 200:
+            return response.json()
+        self._handle_error_response(response)
+
+    async def search(
+        self,
+        query: str,
+        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = None,
+        topic: Literal["general", "news", "finance"] = None,
+        time_range: Literal["day", "week", "month", "year"] = None,
+        start_date: str = None,
+        end_date: str = None,
+        days: int = None,
+        max_results: int = None,
+        include_domains: Sequence[str] = None,
+        exclude_domains: Sequence[str] = None,
+        include_answer: Union[bool, Literal["basic", "advanced"]] = None,
+        include_raw_content: Union[bool, Literal["markdown", "text"]] = None,
+        include_images: bool = None,
+        timeout: float = 60,
+        country: str = None,
+        auto_parameters: bool = None,
+        include_favicon: bool = None,
+        include_usage: bool = None,
+        **kwargs,
     ) -> dict:
         """
-        Internal search method to send the request to the API.
+        Search method. Set search_depth to either "basic", "advanced", "fast", or "ultra-fast".
         """
         data = {
             "query": query,
@@ -100,109 +140,33 @@ class AsyncTavilyClient:
             "auto_parameters": auto_parameters,
             "include_favicon": include_favicon,
             "include_usage": include_usage,
+            **kwargs,
         }
-
         data = {k: v for k, v in data.items() if v is not None}
 
-        if kwargs:
-            data.update(kwargs)
-
-        timeout = min(timeout, 120)
-
-        async with self._client_creator() as client:
-            try:
-                response = await client.post("/search", content=json.dumps(data), timeout=timeout)
-            except httpx.TimeoutException:
-                raise TimeoutError(timeout)
-
-        if response.status_code == 200:
-            return response.json()
-        else:
-            detail = ""
-            try:
-                detail = response.json().get("detail", {}).get("error", None)
-            except Exception:
-                pass
-
-            if response.status_code == 429:
-                raise UsageLimitExceededError(detail)
-            elif response.status_code in [403,432,433]:
-                raise ForbiddenError(detail)
-            elif response.status_code == 401:
-                raise InvalidAPIKeyError(detail)
-            elif response.status_code == 400:
-                raise BadRequestError(detail)
-            else:
-                raise response.raise_for_status()
-
-    async def search(self,
-                     query: str,
-                     search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = None,
-                     topic: Literal["general", "news", "finance"] = None,
-                     time_range: Literal["day", "week", "month", "year"] = None,
-                     start_date: str = None,
-                     end_date: str = None,
-                     days: int = None,
-                     max_results: int = None,
-                     include_domains: Sequence[str] = None,
-                     exclude_domains: Sequence[str] = None,
-                     include_answer: Union[bool, Literal["basic", "advanced"]] = None,
-                     include_raw_content: Union[bool, Literal["markdown", "text"]] = None,
-                     include_images: bool = None,
-                     timeout: float = 60,
-                     country: str = None,
-                     auto_parameters: bool = None,
-                     include_favicon: bool = None,
-                     include_usage: bool = None,
-                     **kwargs,  # Accept custom arguments
-                     ) -> dict:
-        """
-        Combined search method. Set search_depth to either "basic", "advanced", "fast", or "ultra-fast".
-        """
-        timeout = min(timeout, 120)
-        response_dict = await self._search(query,
-                                           search_depth=search_depth,
-                                           topic=topic,
-                                           time_range=time_range,
-                                           start_date=start_date,
-                                           end_date=end_date,
-                                           days=days,
-                                           max_results=max_results,
-                                           include_domains=include_domains,
-                                           exclude_domains=exclude_domains,
-                                           include_answer=include_answer,
-                                           include_raw_content=include_raw_content,
-                                           include_images=include_images,
-                                           timeout=timeout,
-                                           country=country,
-                                           auto_parameters=auto_parameters,
-                                           include_favicon=include_favicon,
-                                           include_usage=include_usage,
-                                           **kwargs,
-                                           )
-
-        tavily_results = response_dict.get("results", [])
-
-        response_dict["results"] = tavily_results
-
+        response_dict = await self._post("/search", data, min(timeout, 120))
+        response_dict.setdefault("results", [])
         return response_dict
 
-    async def _extract(
-            self,
-            urls: Union[List[str], str],
-            include_images: bool = None,
-            extract_depth: Literal["basic", "advanced"] = None,
-            format: Literal["markdown", "text"] = None,
-            timeout: float = 30,
-            include_favicon: bool = None,
-            include_usage: bool = None,
-            query: str = None,
-            chunks_per_source: int = None,
-            **kwargs
+    async def extract(
+        self,
+        urls: Union[List[str], str],
+        include_images: bool = None,
+        extract_depth: Literal["basic", "advanced"] = None,
+        format: Literal["markdown", "text"] = None,
+        timeout: float = 30,
+        include_favicon: bool = None,
+        include_usage: bool = None,
+        query: str = None,
+        chunks_per_source: int = None,
+        **kwargs,
     ) -> dict:
         """
-        Internal extract method to send the request to the API.
-        include_favicon: If True, include the favicon in the extraction results.
+        Extract method to extract content from URLs.
+
+        Args:
+            urls: A single URL or list of URLs to extract content from.
+            include_favicon: If True, include the favicon in the extraction results.
         """
         data = {
             "urls": urls,
@@ -214,99 +178,37 @@ class AsyncTavilyClient:
             "include_usage": include_usage,
             "query": query,
             "chunks_per_source": chunks_per_source,
+            **kwargs,
         }
-
         data = {k: v for k, v in data.items() if v is not None}
 
-        if kwargs:
-            data.update(kwargs)
-
-        async with self._client_creator() as client:
-            try:
-                response = await client.post("/extract", content=json.dumps(data), timeout=timeout)
-            except httpx.TimeoutException:
-                raise TimeoutError(timeout)
-
-        if response.status_code == 200:
-            return response.json()
-        else:
-            detail = ""
-            try:
-                detail = response.json().get("detail", {}).get("error", None)
-            except Exception:
-                pass
-
-
-            if response.status_code == 429:
-                raise UsageLimitExceededError(detail)
-            elif response.status_code in [403,432,433]:
-                raise ForbiddenError(detail)
-            elif response.status_code == 401:
-                raise InvalidAPIKeyError(detail)
-            elif response.status_code == 400:
-                raise BadRequestError(detail)
-            else:
-                raise response.raise_for_status()
-
-    async def extract(self,
-                      urls: Union[List[str], str],  # Accept a list of URLs or a single URL
-                      include_images: bool = None,
-                      extract_depth: Literal["basic", "advanced"] = None,
-                      format: Literal["markdown", "text"] = None,
-                      timeout: float = 30,
-                      include_favicon: bool = None,
-                      include_usage: bool = None,
-                      query: str = None,
-                      chunks_per_source: int = None,
-                      **kwargs,  # Accept custom arguments
-                      ) -> dict:
-        """
-        Combined extract method.
-        include_favicon: If True, include the favicon in the extraction results.
-        """
-        response_dict = await self._extract(urls,
-                                            include_images,
-                                            extract_depth,
-                                            format,
-                                            timeout,
-                                            include_favicon=include_favicon,
-                                            include_usage=include_usage,
-                                            query=query,
-                                            chunks_per_source=chunks_per_source,
-                                            **kwargs,
-                                            )
-
-        tavily_results = response_dict.get("results", [])
-        failed_results = response_dict.get("failed_results", [])
-
-        response_dict["results"] = tavily_results
-        response_dict["failed_results"] = failed_results
-
+        response_dict = await self._post("/extract", data, timeout)
+        response_dict.setdefault("results", [])
+        response_dict.setdefault("failed_results", [])
         return response_dict
     
-    async def _crawl(self,
-               url: str,
-               max_depth: int = None,
-               max_breadth: int = None,
-               limit: int = None,
-               instructions: str = None,
-               select_paths: Sequence[str] = None,
-               select_domains: Sequence[str] = None,
-               exclude_paths: Sequence[str] = None,
-               exclude_domains: Sequence[str] = None,
-               allow_external: bool = None,
-               include_images: bool = None,
-               extract_depth: Literal["basic", "advanced"] = None,
-               format: Literal["markdown", "text"] = None,
-               timeout: float = 150,
-               include_favicon: bool = None,
-               include_usage: bool = None,
-               chunks_per_source: int = None,
-               **kwargs
-               ) -> dict:
-        """
-        Internal crawl method to send the request to the API.
-        """
+    async def crawl(
+        self,
+        url: str,
+        max_depth: int = None,
+        max_breadth: int = None,
+        limit: int = None,
+        instructions: str = None,
+        select_paths: Sequence[str] = None,
+        select_domains: Sequence[str] = None,
+        exclude_paths: Sequence[str] = None,
+        exclude_domains: Sequence[str] = None,
+        allow_external: bool = None,
+        include_images: bool = None,
+        extract_depth: Literal["basic", "advanced"] = None,
+        format: Literal["markdown", "text"] = None,
+        timeout: float = 150,
+        include_favicon: bool = None,
+        include_usage: bool = None,
+        chunks_per_source: int = None,
+        **kwargs,
+    ) -> dict:
+        """Crawl method to crawl a website and extract content."""
         data = {
             "url": url,
             "max_depth": max_depth,
@@ -325,103 +227,30 @@ class AsyncTavilyClient:
             "include_favicon": include_favicon,
             "include_usage": include_usage,
             "chunks_per_source": chunks_per_source,
+            **kwargs,
         }
-
-        if kwargs:
-            data.update(kwargs)
-
         data = {k: v for k, v in data.items() if v is not None}
 
-        async with self._client_creator() as client:
-            try:
-                response = await client.post("/crawl", content=json.dumps(data), timeout=timeout)
-            except httpx.TimeoutException:
-                raise TimeoutError(timeout)
-
-            if response.status_code == 200:
-                return response.json()
-            else:
-                detail = ""
-                try:
-                    detail = response.json().get("detail", {}).get("error", None)
-                except Exception:
-                    pass
-
-                if response.status_code == 429:
-                    raise UsageLimitExceededError(detail)
-                elif response.status_code in [403,432,433]:
-                    raise ForbiddenError(detail)
-                elif response.status_code == 401:
-                    raise InvalidAPIKeyError(detail)
-                elif response.status_code == 400:
-                    raise BadRequestError(detail)
-                else:
-                    raise response.raise_for_status()
-
-    async def crawl(self,
-                    url: str,
-                    max_depth: int = None,
-                    max_breadth: int = None,
-                    limit: int = None,
-                    instructions: str = None,
-                    select_paths: Sequence[str] = None,
-                    select_domains: Sequence[str] = None,
-                    exclude_paths: Sequence[str] = None,
-                    exclude_domains: Sequence[str] = None,
-                    allow_external: bool = None,
-                    extract_depth: Literal["basic", "advanced"] = None,
-                    include_images: bool = None,
-                    format: Literal["markdown", "text"] = None,
-                    timeout: float = 150,
-                    include_favicon: bool = None,
-                    include_usage: bool = None,
-                    chunks_per_source: int = None,
-                    **kwargs
-                    ) -> dict:
-        """
-        Combined crawl method.
-        
-        """
-        response_dict = await self._crawl(url,
-                                    max_depth=max_depth,
-                                    max_breadth=max_breadth,
-                                    limit=limit,
-                                    instructions=instructions,
-                                    select_paths=select_paths,
-                                    select_domains=select_domains,
-                                    exclude_paths=exclude_paths,
-                                    exclude_domains=exclude_domains,
-                                    allow_external=allow_external,
-                                    extract_depth=extract_depth,
-                                    include_images=include_images,
-                                    format=format,
-                                    timeout=timeout,
-                                    include_favicon=include_favicon,
-                                    include_usage=include_usage,
-                                    chunks_per_source=chunks_per_source,
-                                    **kwargs)
-
-        return response_dict
+        return await self._post("/crawl", data, timeout)
     
-    async def _map(self,
-               url: str,
-               max_depth: int = None,
-               max_breadth: int = None,
-               limit: int = None,
-               instructions: str = None,
-               select_paths: Sequence[str] = None,
-               select_domains: Sequence[str] = None,
-               exclude_paths: Sequence[str] = None,
-               exclude_domains: Sequence[str] = None,
-               allow_external: bool = None,
-               include_images: bool = None,
-               timeout: float = 150,
-               include_usage: bool = None,
-               **kwargs
-               ) -> dict:
-        """
-        Internal map method to send the request to the API.
-        """
+    async def map(
+        self,
+        url: str,
+        max_depth: int = None,
+        max_breadth: int = None,
+        limit: int = None,
+        instructions: str = None,
+        select_paths: Sequence[str] = None,
+        select_domains: Sequence[str] = None,
+        exclude_paths: Sequence[str] = None,
+        exclude_domains: Sequence[str] = None,
+        allow_external: bool = None,
+        include_images: bool = None,
+        timeout: float = 150,
+        include_usage: bool = None,
+        **kwargs,
+    ) -> dict:
+        """Map method to discover URLs on a website."""
         data = {
             "url": url,
             "max_depth": max_depth,
@@ -436,192 +265,182 @@ class AsyncTavilyClient:
             "include_images": include_images,
             "timeout": timeout,
             "include_usage": include_usage,
+            **kwargs,
         }
-
-        if kwargs:
-            data.update(kwargs)
-
         data = {k: v for k, v in data.items() if v is not None}
 
-        async with self._client_creator() as client:
-            try:
-                response = await client.post("/map", content=json.dumps(data), timeout=timeout)
-            except httpx.TimeoutException:
-                raise TimeoutError(timeout)
+        return await self._post("/map", data, timeout)
 
-            if response.status_code == 200:
-                return response.json()
-            else:
-                detail = ""
-                try:
-                    detail = response.json().get("detail", {}).get("error", None)
-                except Exception:
-                    pass
-
-                if response.status_code == 429:
-                    raise UsageLimitExceededError(detail)
-                elif response.status_code in [403,432,433]:
-                    raise ForbiddenError(detail)
-                elif response.status_code == 401:
-                    raise InvalidAPIKeyError(detail)
-                elif response.status_code == 400:
-                    raise BadRequestError(detail)
-                else:
-                    raise response.raise_for_status()
-
-    async def map(self,
-                    url: str,
-                    max_depth: int = None,
-                    max_breadth: int = None,
-                    limit: int = None,
-                    instructions: str = None,
-                    select_paths: Sequence[str] = None,
-                    select_domains: Sequence[str] = None,
-                    exclude_paths: Sequence[str] = None,
-                    exclude_domains: Sequence[str] = None,
-                    allow_external: bool = None,
-                    include_images: bool = None,
-                    timeout: float = 150,
-                    include_usage: bool = None,
-                    **kwargs
-                    ) -> dict:
-        """
-        Combined map method.
-
-        """
-        response_dict = await self._map(url,
-                                    max_depth=max_depth,
-                                    max_breadth=max_breadth,
-                                    limit=limit,
-                                    instructions=instructions,
-                                    select_paths=select_paths,
-                                    select_domains=select_domains,
-                                    exclude_paths=exclude_paths,
-                                    exclude_domains=exclude_domains,
-                                    allow_external=allow_external,
-                                    include_images=include_images,
-                                    timeout=timeout,
-                                    include_usage=include_usage,
-                                    **kwargs)
-
-        return response_dict
-
-    async def get_search_context(self,
-                                 query: str,
-                                 search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "basic",
-                                 topic: Literal["general", "news", "finance"] = "general",
-                                 days: int = 7,
-                                 max_results: int = 5,
-                                 include_domains: Sequence[str] = None,
-                                 exclude_domains: Sequence[str] = None,
-                                 max_tokens: int = 4000,
-                                 timeout: float = 60,
-                                 country: str = None,
-                                 include_favicon: bool = None,
-                                 **kwargs,  # Accept custom arguments
-                                 ) -> str:
+    async def get_search_context(
+        self,
+        query: str,
+        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "basic",
+        topic: Literal["general", "news", "finance"] = "general",
+        days: int = 7,
+        max_results: int = 5,
+        include_domains: Sequence[str] = None,
+        exclude_domains: Sequence[str] = None,
+        max_tokens: int = 4000,
+        timeout: float = 60,
+        country: str = None,
+        include_favicon: bool = None,
+        **kwargs,
+    ) -> str:
         """
         Get the search context for a query. Useful for getting only related content from retrieved websites
         without having to deal with context extraction and limitation yourself.
 
-        max_tokens: The maximum number of tokens to return (based on openai token compute). Defaults to 4000.
+        Args:
+            max_tokens: The maximum number of tokens to return (based on openai token compute). Defaults to 4000.
 
-        Returns a string of JSON containing the search context up to context limit.
+        Returns:
+            A string of JSON containing the search context up to context limit.
         """
-        timeout = min(timeout, 120)
-        response_dict = await self._search(query,
-                                           search_depth=search_depth,
-                                           topic=topic,
-                                           days=days,
-                                           max_results=max_results,
-                                           include_domains=include_domains,
-                                           exclude_domains=exclude_domains,
-                                           include_answer=False,
-                                           include_raw_content=False,
-                                           include_images=False,
-                                           timeout = timeout,
-                                           country=country,
-                                           include_favicon=include_favicon,
-                                           **kwargs,
-                                           )
+        response_dict = await self.search(
+            query,
+            search_depth=search_depth,
+            topic=topic,
+            days=days,
+            max_results=max_results,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+            include_answer=False,
+            include_raw_content=False,
+            include_images=False,
+            timeout=timeout,
+            country=country,
+            include_favicon=include_favicon,
+            **kwargs,
+        )
         sources = response_dict.get("results", [])
         context = [{"url": source["url"], "content": source["content"]} for source in sources]
         return json.dumps(get_max_items_from_list(context, max_tokens))
 
-    async def qna_search(self,
-                         query: str,
-                         search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
-                         topic: Literal["general", "news", "finance"] = "general",
-                         days: int = 7,
-                         max_results: int = 5,
-                         include_domains: Sequence[str] = None,
-                         exclude_domains: Sequence[str] = None,
-                         timeout: float = 60,
-                         country: str = None,
-                         include_favicon: bool = None,
-                         **kwargs,  # Accept custom arguments
-                         ) -> str:
-        """
-        Q&A search method. Search depth is advanced by default to get the best answer.
-        """
-        timeout = min(timeout, 120)
-        response_dict = await self._search(query,
-                                           search_depth=search_depth,
-                                           topic=topic,
-                                           days=days,
-                                           max_results=max_results,
-                                           include_domains=include_domains,
-                                           exclude_domains=exclude_domains,
-                                           include_raw_content=False,
-                                           include_images=False,
-                                           include_answer=True,
-                                           timeout = timeout,
-                                           country=country,
-                                           include_favicon=include_favicon,
-                                           **kwargs,
-                                           )
+    async def qna_search(
+        self,
+        query: str,
+        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
+        topic: Literal["general", "news", "finance"] = "general",
+        days: int = 7,
+        max_results: int = 5,
+        include_domains: Sequence[str] = None,
+        exclude_domains: Sequence[str] = None,
+        timeout: float = 60,
+        country: str = None,
+        include_favicon: bool = None,
+        **kwargs,
+    ) -> str:
+        """Q&A search method. Search depth is advanced by default to get the best answer."""
+        response_dict = await self.search(
+            query,
+            search_depth=search_depth,
+            topic=topic,
+            days=days,
+            max_results=max_results,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+            include_raw_content=False,
+            include_images=False,
+            include_answer=True,
+            timeout=timeout,
+            country=country,
+            include_favicon=include_favicon,
+            **kwargs,
+        )
         return response_dict.get("answer", "")
 
-    async def get_company_info(self,
-                               query: str,
-                               search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
-                               max_results: int = 5,
-                               timeout: float = 60,
-                               country: str = None,
-                               ) -> Sequence[dict]:
-        """ Company information search method. Search depth is advanced by default to get the best answer. """
-        timeout = min(timeout, 120)
+    async def get_company_info(
+        self,
+        query: str,
+        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
+        max_results: int = 5,
+        timeout: float = 60,
+        country: str = None,
+    ) -> Sequence[dict]:
+        """Company information search method. Search depth is advanced by default to get the best answer."""
+        async def perform_search(topic: str) -> dict:
+            return await self.search(
+                query,
+                search_depth=search_depth,
+                topic=topic,
+                max_results=max_results,
+                include_answer=False,
+                timeout=timeout,
+                country=country,
+            )
 
-        async def _perform_search(topic: str):
-            return await self._search(query,
-                                      search_depth=search_depth,
-                                      topic=topic,
-                                      max_results=max_results,
-                                      include_answer=False,
-                                      timeout = timeout,
-                                      country=country)
+        results = await asyncio.gather(*[perform_search(topic) for topic in self._company_info_tags])
 
         all_results = []
-        for data in await asyncio.gather(*[_perform_search(topic) for topic in self._company_info_tags]):
-            if "results" in data:
-                all_results.extend(data["results"])
+        for data in results:
+            all_results.extend(data.get("results", []))
 
-        # Sort all the results by score in descending order and take the top 'max_results' items
-        sorted_results = sorted(all_results, key=lambda x: x["score"], reverse=True)[:max_results]
+        return sorted(all_results, key=lambda x: x["score"], reverse=True)[:max_results]
 
-        return sorted_results
+    def _handle_stream_error(self, status_code: int, error_text: str) -> None:
+        """Handle error responses during streaming."""
+        if status_code == 429:
+            raise UsageLimitExceededError(error_text)
+        if status_code in (403, 432, 433):
+            raise ForbiddenError(error_text)
+        if status_code == 401:
+            raise InvalidAPIKeyError(error_text)
+        if status_code == 400:
+            raise BadRequestError(error_text)
+        raise Exception(f"Error {status_code}: {error_text}")
 
-    def _research(self,
-                  input: str,
-                  model: Literal["mini", "pro", "auto"] = None,
-                  output_schema: dict = None,
-                  stream: bool = False,
-                  citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
-                  timeout: Optional[float] = None,
-                  **kwargs
-                  ) -> Union[AsyncGenerator[bytes, None], Awaitable[dict]]:
+    async def _research_stream(
+        self,
+        data: dict,
+        timeout: Optional[float],
+    ) -> AsyncGenerator[bytes, None]:
+        """Stream research results from the API."""
+        try:
+            async with self._client.stream(
+                "POST",
+                "/research",
+                content=json.dumps(data),
+                timeout=timeout,
+            ) as response:
+                if response.status_code != 200:
+                    try:
+                        error_bytes = await response.aread()
+                        error_text = error_bytes.decode("utf-8") if isinstance(error_bytes, bytes) else error_bytes
+                    except Exception:
+                        error_text = "Unknown error"
+                    self._handle_stream_error(response.status_code, error_text)
+
+                async for chunk in response.aiter_bytes():
+                    if chunk:
+                        yield chunk
+        except httpx.TimeoutException:
+            raise TimeoutError(timeout)
+
+    async def research(
+        self,
+        input: str,
+        model: Literal["mini", "pro", "auto"] = None,
+        output_schema: dict = None,
+        stream: bool = False,
+        citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Union[dict, AsyncGenerator[bytes, None]]:
         """
-        Internal research method to send the request to the API.
+        Research method to create a research task.
+
+        Args:
+            input: The research task description (required).
+            model: Research depth - must be either 'mini', 'pro', or 'auto'.
+            output_schema: Schema for the 'structured_output' response format (JSON Schema dict).
+            stream: Whether to stream the research task.
+            citation_format: Citation format - must be either 'numbered', 'mla', 'apa', or 'chicago'.
+            timeout: Optional HTTP request timeout in seconds.
+            **kwargs: Additional custom arguments.
+
+        Returns:
+            When stream=False: dict - the response dictionary.
+            When stream=True: AsyncGenerator[bytes, None] - iterate over this to get streaming chunks.
         """
         data = {
             "input": input,
@@ -629,154 +448,28 @@ class AsyncTavilyClient:
             "output_schema": output_schema,
             "stream": stream,
             "citation_format": citation_format,
+            **kwargs,
         }
-
         data = {k: v for k, v in data.items() if v is not None}
 
-        if kwargs:
-            data.update(kwargs)
-
         if stream:
-            async def stream_generator() -> AsyncGenerator[bytes, None]:
-                try:
-                    async with self._client_creator() as client:
-                        async with client.stream(
-                            "POST",
-                            "/research",
-                            content=json.dumps(data),
-                            timeout=timeout
-                        ) as response:
-                            if response.status_code != 200:
-                                try:
-                                    error_text = await response.aread()
-                                    error_text = error_text.decode('utf-8') if isinstance(error_text, bytes) else error_text
-                                except Exception:
-                                    error_text = "Unknown error"
-                                
-                                if response.status_code == 429:
-                                    raise UsageLimitExceededError(error_text)
-                                elif response.status_code in [403,432,433]:
-                                    raise ForbiddenError(error_text)
-                                elif response.status_code == 401:
-                                    raise InvalidAPIKeyError(error_text)
-                                elif response.status_code == 400:
-                                    raise BadRequestError(error_text)
-                                else:
-                                    raise Exception(f"Error {response.status_code}: {error_text}")
-                            
-                            async for chunk in response.aiter_bytes():
-                                if chunk:
-                                    yield chunk
-                except httpx.TimeoutException:
-                    raise TimeoutError(timeout)
-                except Exception as e:
-                    raise Exception(f"Error during research stream: {str(e)}")
-            
-            return stream_generator()
-        else:
-            async def _make_request():
-                async with self._client_creator() as client:
-                    try:
-                        response = await client.post("/research", content=json.dumps(data), timeout=timeout)
-                    except httpx.TimeoutException:
-                        raise TimeoutError(timeout)
+            return self._research_stream(data, timeout)
 
-                    if response.status_code == 200:
-                        return response.json()
-                    else:
-                        detail = ""
-                        try:
-                            detail = response.json().get("detail", {}).get("error", None)
-                        except Exception:
-                            pass
+        return await self._post("/research", data, timeout)
 
-                        if response.status_code == 429:
-                            raise UsageLimitExceededError(detail)
-                        elif response.status_code in [403,432,433]:
-                            raise ForbiddenError(detail)
-                        elif response.status_code == 401:
-                            raise InvalidAPIKeyError(detail)
-                        elif response.status_code == 400:
-                            raise BadRequestError(detail)
-                        else:
-                            raise response.raise_for_status()
-            
-            return _make_request()
-
-    async def research(self,
-                       input: str,
-                       model: Literal["mini", "pro", "auto"] = None,
-                       output_schema: dict = None,
-                       stream: bool = False,
-                       citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
-                       timeout: Optional[float] = None,
-                       **kwargs
-                       ) -> Union[dict, AsyncGenerator[bytes, None]]:
-        """
-        Research method to create a research task.
-        
-        Args:
-            input: The research task description (required).
-            model: Research depth - must be either 'mini', 'pro', or 'auto'.
-            output_schema: Schema for the 'structured_output' response format (JSON Schema dict).
-            stream: Whether to stream the research task.
-            citation_format: Citation format - must be either 'numbered', 'mla', 'apa', or 'chicago'.
-            timeout: Optional HTTP request timeout in seconds. 
-            **kwargs: Additional custom arguments.
-        
-        Returns:
-            When stream=False: dict - the response dictionary.
-            When stream=True: AsyncGenerator[bytes, None] - iterate over this to get streaming chunks.
-        """
-        result = self._research(
-                input=input,
-                model=model,
-                output_schema=output_schema,
-                stream=stream,
-                citation_format=citation_format,
-                timeout=timeout,
-                **kwargs
-        )
-        if stream:
-            return result # Don't await the result, it's an AsyncGenerator that will be lazy and only execute when iterated over with async for
-        else:
-            return await result 
-
-    async def get_research(self,
-                           request_id: str
-                           ) -> dict:
+    async def get_research(self, request_id: str) -> dict:
         """
         Get research results by request_id.
-        
+
         Args:
             request_id: The research request ID.
-        
+
         Returns:
             dict: Research response containing request_id, created_at, completed_at, status, content, and sources.
         """
-        async with self._client_creator() as client:
-            try:
-                response = await client.get(f"/research/{request_id}")
-            except Exception as e:
-                raise Exception(f"Error getting research: {e}")
+        response = await self._client.get(f"/research/{request_id}")
 
-            if response.status_code in (200, 202):
-                data = response.json()
-                return data
-            else:
-                detail = ""
-                try:
-                    detail = response.json().get("detail", {}).get("error", None)
-                except Exception:
-                    pass
+        if response.status_code in (200, 202):
+            return response.json()
 
-                if response.status_code == 429:
-                    raise UsageLimitExceededError(detail)
-                elif response.status_code in [403,432,433]:
-                    raise ForbiddenError(detail)
-                elif response.status_code == 401:
-                    raise InvalidAPIKeyError(detail)
-                elif response.status_code == 400:
-                    raise BadRequestError(detail)
-                else:
-                    raise response.raise_for_status()
+        self._handle_error_response(response)

--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import os
-from typing import Literal, Sequence, Optional, List, Union, AsyncGenerator
+from typing import Literal, Sequence, Optional, List, Union, AsyncGenerator, Awaitable
 
 import httpx
 
@@ -14,15 +14,12 @@ class AsyncTavilyClient:
     Async Tavily API client class.
     """
 
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        company_info_tags: Sequence[str] = ("news", "general", "finance"),
-        proxies: Optional[dict[str, str]] = None,
-        api_base_url: Optional[str] = None,
-        client_source: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ):
+    def __init__(self, api_key: Optional[str] = None,
+                 company_info_tags: Sequence[str] = ("news", "general", "finance"),
+                 proxies: Optional[dict[str, str]] = None,
+                 api_base_url: Optional[str] = None,
+                 client_source: Optional[str] = None,
+                 project_id: Optional[str] = None):
         if api_key is None:
             api_key = os.getenv("TAVILY_API_KEY")
 
@@ -35,6 +32,7 @@ class AsyncTavilyClient:
             "http://": proxies.get("http", os.getenv("TAVILY_HTTP_PROXY")),
             "https://": proxies.get("https", os.getenv("TAVILY_HTTPS_PROXY")),
         }
+
         mapped_proxies = {key: value for key, value in mapped_proxies.items() if value}
 
         proxy_mounts = (
@@ -45,6 +43,9 @@ class AsyncTavilyClient:
 
         tavily_project = project_id or os.getenv("TAVILY_PROJECT")
 
+        self._api_base_url = api_base_url or "https://api.tavily.com"
+
+        # Create a persistent client for connection pooling
         self._client = httpx.AsyncClient(
             headers={
                 "Content-Type": "application/json",
@@ -52,75 +53,45 @@ class AsyncTavilyClient:
                 "X-Client-Source": client_source or "tavily-python",
                 **({"X-Project-ID": tavily_project} if tavily_project else {})
             },
-            base_url=api_base_url or "https://api.tavily.com",
-            mounts=proxy_mounts,
+            base_url=self._api_base_url,
+            mounts=proxy_mounts
         )
         self._company_info_tags = company_info_tags
 
-    async def close(self) -> None:
+    async def close(self):
         """Close the client and release connection pool resources."""
         await self._client.aclose()
 
-    async def __aenter__(self) -> "AsyncTavilyClient":
+    async def __aenter__(self):
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
 
-    def _handle_error_response(self, response: httpx.Response) -> None:
-        """Handle non-200 HTTP responses by raising appropriate exceptions."""
-        detail = ""
-        try:
-            detail = response.json().get("detail", {}).get("error", None)
-        except Exception:
-            pass
-
-        status = response.status_code
-        if status == 429:
-            raise UsageLimitExceededError(detail)
-        if status in (403, 432, 433):
-            raise ForbiddenError(detail)
-        if status == 401:
-            raise InvalidAPIKeyError(detail)
-        if status == 400:
-            raise BadRequestError(detail)
-        response.raise_for_status()
-
-    async def _post(self, endpoint: str, data: dict, timeout: float) -> dict:
-        """Make a POST request and handle response/errors."""
-        try:
-            response = await self._client.post(endpoint, content=json.dumps(data), timeout=timeout)
-        except httpx.TimeoutException:
-            raise TimeoutError(timeout)
-
-        if response.status_code == 200:
-            return response.json()
-        self._handle_error_response(response)
-
-    async def search(
-        self,
-        query: str,
-        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = None,
-        topic: Literal["general", "news", "finance"] = None,
-        time_range: Literal["day", "week", "month", "year"] = None,
-        start_date: str = None,
-        end_date: str = None,
-        days: int = None,
-        max_results: int = None,
-        include_domains: Sequence[str] = None,
-        exclude_domains: Sequence[str] = None,
-        include_answer: Union[bool, Literal["basic", "advanced"]] = None,
-        include_raw_content: Union[bool, Literal["markdown", "text"]] = None,
-        include_images: bool = None,
-        timeout: float = 60,
-        country: str = None,
-        auto_parameters: bool = None,
-        include_favicon: bool = None,
-        include_usage: bool = None,
-        **kwargs,
+    async def _search(
+            self,
+            query: str,
+            search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = None,
+            topic: Literal["general", "news", "finance"] = None,
+            time_range: Literal["day", "week", "month", "year"] = None,
+            start_date: str = None,
+            end_date: str = None,
+            days: int = None,
+            max_results: int = None,
+            include_domains: Sequence[str] = None,
+            exclude_domains: Sequence[str] = None,
+            include_answer: Union[bool, Literal["basic", "advanced"]] = None,
+            include_raw_content: Union[bool, Literal["markdown", "text"]] = None,
+            include_images: bool = None,
+            timeout: float = 60,
+            country: str = None,
+            auto_parameters: bool = None,
+            include_favicon: bool = None,
+            include_usage: bool = None,
+            **kwargs,
     ) -> dict:
         """
-        Search method. Set search_depth to either "basic", "advanced", "fast", or "ultra-fast".
+        Internal search method to send the request to the API.
         """
         data = {
             "query": query,
@@ -140,33 +111,108 @@ class AsyncTavilyClient:
             "auto_parameters": auto_parameters,
             "include_favicon": include_favicon,
             "include_usage": include_usage,
-            **kwargs,
         }
+
         data = {k: v for k, v in data.items() if v is not None}
 
-        response_dict = await self._post("/search", data, min(timeout, 120))
-        response_dict.setdefault("results", [])
+        if kwargs:
+            data.update(kwargs)
+
+        timeout = min(timeout, 120)
+
+        try:
+            response = await self._client.post("/search", content=json.dumps(data), timeout=timeout)
+        except httpx.TimeoutException:
+            raise TimeoutError(timeout)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            detail = ""
+            try:
+                detail = response.json().get("detail", {}).get("error", None)
+            except Exception:
+                pass
+
+            if response.status_code == 429:
+                raise UsageLimitExceededError(detail)
+            elif response.status_code in [403,432,433]:
+                raise ForbiddenError(detail)
+            elif response.status_code == 401:
+                raise InvalidAPIKeyError(detail)
+            elif response.status_code == 400:
+                raise BadRequestError(detail)
+            else:
+                raise response.raise_for_status()
+
+    async def search(self,
+                     query: str,
+                     search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = None,
+                     topic: Literal["general", "news", "finance"] = None,
+                     time_range: Literal["day", "week", "month", "year"] = None,
+                     start_date: str = None,
+                     end_date: str = None,
+                     days: int = None,
+                     max_results: int = None,
+                     include_domains: Sequence[str] = None,
+                     exclude_domains: Sequence[str] = None,
+                     include_answer: Union[bool, Literal["basic", "advanced"]] = None,
+                     include_raw_content: Union[bool, Literal["markdown", "text"]] = None,
+                     include_images: bool = None,
+                     timeout: float = 60,
+                     country: str = None,
+                     auto_parameters: bool = None,
+                     include_favicon: bool = None,
+                     include_usage: bool = None,
+                     **kwargs,  # Accept custom arguments
+                     ) -> dict:
+        """
+        Combined search method. Set search_depth to either "basic", "advanced", "fast", or "ultra-fast".
+        """
+        timeout = min(timeout, 120)
+        response_dict = await self._search(query,
+                                           search_depth=search_depth,
+                                           topic=topic,
+                                           time_range=time_range,
+                                           start_date=start_date,
+                                           end_date=end_date,
+                                           days=days,
+                                           max_results=max_results,
+                                           include_domains=include_domains,
+                                           exclude_domains=exclude_domains,
+                                           include_answer=include_answer,
+                                           include_raw_content=include_raw_content,
+                                           include_images=include_images,
+                                           timeout=timeout,
+                                           country=country,
+                                           auto_parameters=auto_parameters,
+                                           include_favicon=include_favicon,
+                                           include_usage=include_usage,
+                                           **kwargs,
+                                           )
+
+        tavily_results = response_dict.get("results", [])
+
+        response_dict["results"] = tavily_results
+
         return response_dict
 
-    async def extract(
-        self,
-        urls: Union[List[str], str],
-        include_images: bool = None,
-        extract_depth: Literal["basic", "advanced"] = None,
-        format: Literal["markdown", "text"] = None,
-        timeout: float = 30,
-        include_favicon: bool = None,
-        include_usage: bool = None,
-        query: str = None,
-        chunks_per_source: int = None,
-        **kwargs,
+    async def _extract(
+            self,
+            urls: Union[List[str], str],
+            include_images: bool = None,
+            extract_depth: Literal["basic", "advanced"] = None,
+            format: Literal["markdown", "text"] = None,
+            timeout: float = 30,
+            include_favicon: bool = None,
+            include_usage: bool = None,
+            query: str = None,
+            chunks_per_source: int = None,
+            **kwargs
     ) -> dict:
         """
-        Extract method to extract content from URLs.
-
-        Args:
-            urls: A single URL or list of URLs to extract content from.
-            include_favicon: If True, include the favicon in the extraction results.
+        Internal extract method to send the request to the API.
+        include_favicon: If True, include the favicon in the extraction results.
         """
         data = {
             "urls": urls,
@@ -178,37 +224,98 @@ class AsyncTavilyClient:
             "include_usage": include_usage,
             "query": query,
             "chunks_per_source": chunks_per_source,
-            **kwargs,
         }
+
         data = {k: v for k, v in data.items() if v is not None}
 
-        response_dict = await self._post("/extract", data, timeout)
-        response_dict.setdefault("results", [])
-        response_dict.setdefault("failed_results", [])
+        if kwargs:
+            data.update(kwargs)
+
+        try:
+            response = await self._client.post("/extract", content=json.dumps(data), timeout=timeout)
+        except httpx.TimeoutException:
+            raise TimeoutError(timeout)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            detail = ""
+            try:
+                detail = response.json().get("detail", {}).get("error", None)
+            except Exception:
+                pass
+
+
+            if response.status_code == 429:
+                raise UsageLimitExceededError(detail)
+            elif response.status_code in [403,432,433]:
+                raise ForbiddenError(detail)
+            elif response.status_code == 401:
+                raise InvalidAPIKeyError(detail)
+            elif response.status_code == 400:
+                raise BadRequestError(detail)
+            else:
+                raise response.raise_for_status()
+
+    async def extract(self,
+                      urls: Union[List[str], str],  # Accept a list of URLs or a single URL
+                      include_images: bool = None,
+                      extract_depth: Literal["basic", "advanced"] = None,
+                      format: Literal["markdown", "text"] = None,
+                      timeout: float = 30,
+                      include_favicon: bool = None,
+                      include_usage: bool = None,
+                      query: str = None,
+                      chunks_per_source: int = None,
+                      **kwargs,  # Accept custom arguments
+                      ) -> dict:
+        """
+        Combined extract method.
+        include_favicon: If True, include the favicon in the extraction results.
+        """
+        response_dict = await self._extract(urls,
+                                            include_images,
+                                            extract_depth,
+                                            format,
+                                            timeout,
+                                            include_favicon=include_favicon,
+                                            include_usage=include_usage,
+                                            query=query,
+                                            chunks_per_source=chunks_per_source,
+                                            **kwargs,
+                                            )
+
+        tavily_results = response_dict.get("results", [])
+        failed_results = response_dict.get("failed_results", [])
+
+        response_dict["results"] = tavily_results
+        response_dict["failed_results"] = failed_results
+
         return response_dict
-    
-    async def crawl(
-        self,
-        url: str,
-        max_depth: int = None,
-        max_breadth: int = None,
-        limit: int = None,
-        instructions: str = None,
-        select_paths: Sequence[str] = None,
-        select_domains: Sequence[str] = None,
-        exclude_paths: Sequence[str] = None,
-        exclude_domains: Sequence[str] = None,
-        allow_external: bool = None,
-        include_images: bool = None,
-        extract_depth: Literal["basic", "advanced"] = None,
-        format: Literal["markdown", "text"] = None,
-        timeout: float = 150,
-        include_favicon: bool = None,
-        include_usage: bool = None,
-        chunks_per_source: int = None,
-        **kwargs,
-    ) -> dict:
-        """Crawl method to crawl a website and extract content."""
+
+    async def _crawl(self,
+               url: str,
+               max_depth: int = None,
+               max_breadth: int = None,
+               limit: int = None,
+               instructions: str = None,
+               select_paths: Sequence[str] = None,
+               select_domains: Sequence[str] = None,
+               exclude_paths: Sequence[str] = None,
+               exclude_domains: Sequence[str] = None,
+               allow_external: bool = None,
+               include_images: bool = None,
+               extract_depth: Literal["basic", "advanced"] = None,
+               format: Literal["markdown", "text"] = None,
+               timeout: float = 150,
+               include_favicon: bool = None,
+               include_usage: bool = None,
+               chunks_per_source: int = None,
+               **kwargs
+               ) -> dict:
+        """
+        Internal crawl method to send the request to the API.
+        """
         data = {
             "url": url,
             "max_depth": max_depth,
@@ -227,30 +334,102 @@ class AsyncTavilyClient:
             "include_favicon": include_favicon,
             "include_usage": include_usage,
             "chunks_per_source": chunks_per_source,
-            **kwargs,
         }
+
+        if kwargs:
+            data.update(kwargs)
+
         data = {k: v for k, v in data.items() if v is not None}
 
-        return await self._post("/crawl", data, timeout)
-    
-    async def map(
-        self,
-        url: str,
-        max_depth: int = None,
-        max_breadth: int = None,
-        limit: int = None,
-        instructions: str = None,
-        select_paths: Sequence[str] = None,
-        select_domains: Sequence[str] = None,
-        exclude_paths: Sequence[str] = None,
-        exclude_domains: Sequence[str] = None,
-        allow_external: bool = None,
-        include_images: bool = None,
-        timeout: float = 150,
-        include_usage: bool = None,
-        **kwargs,
-    ) -> dict:
-        """Map method to discover URLs on a website."""
+        try:
+            response = await self._client.post("/crawl", content=json.dumps(data), timeout=timeout)
+        except httpx.TimeoutException:
+            raise TimeoutError(timeout)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            detail = ""
+            try:
+                detail = response.json().get("detail", {}).get("error", None)
+            except Exception:
+                pass
+
+            if response.status_code == 429:
+                raise UsageLimitExceededError(detail)
+            elif response.status_code in [403,432,433]:
+                raise ForbiddenError(detail)
+            elif response.status_code == 401:
+                raise InvalidAPIKeyError(detail)
+            elif response.status_code == 400:
+                raise BadRequestError(detail)
+            else:
+                raise response.raise_for_status()
+
+    async def crawl(self,
+                    url: str,
+                    max_depth: int = None,
+                    max_breadth: int = None,
+                    limit: int = None,
+                    instructions: str = None,
+                    select_paths: Sequence[str] = None,
+                    select_domains: Sequence[str] = None,
+                    exclude_paths: Sequence[str] = None,
+                    exclude_domains: Sequence[str] = None,
+                    allow_external: bool = None,
+                    extract_depth: Literal["basic", "advanced"] = None,
+                    include_images: bool = None,
+                    format: Literal["markdown", "text"] = None,
+                    timeout: float = 150,
+                    include_favicon: bool = None,
+                    include_usage: bool = None,
+                    chunks_per_source: int = None,
+                    **kwargs
+                    ) -> dict:
+        """
+        Combined crawl method.
+
+        """
+        response_dict = await self._crawl(url,
+                                    max_depth=max_depth,
+                                    max_breadth=max_breadth,
+                                    limit=limit,
+                                    instructions=instructions,
+                                    select_paths=select_paths,
+                                    select_domains=select_domains,
+                                    exclude_paths=exclude_paths,
+                                    exclude_domains=exclude_domains,
+                                    allow_external=allow_external,
+                                    extract_depth=extract_depth,
+                                    include_images=include_images,
+                                    format=format,
+                                    timeout=timeout,
+                                    include_favicon=include_favicon,
+                                    include_usage=include_usage,
+                                    chunks_per_source=chunks_per_source,
+                                    **kwargs)
+
+        return response_dict
+
+    async def _map(self,
+               url: str,
+               max_depth: int = None,
+               max_breadth: int = None,
+               limit: int = None,
+               instructions: str = None,
+               select_paths: Sequence[str] = None,
+               select_domains: Sequence[str] = None,
+               exclude_paths: Sequence[str] = None,
+               exclude_domains: Sequence[str] = None,
+               allow_external: bool = None,
+               include_images: bool = None,
+               timeout: float = 150,
+               include_usage: bool = None,
+               **kwargs
+               ) -> dict:
+        """
+        Internal map method to send the request to the API.
+        """
         data = {
             "url": url,
             "max_depth": max_depth,
@@ -265,167 +444,279 @@ class AsyncTavilyClient:
             "include_images": include_images,
             "timeout": timeout,
             "include_usage": include_usage,
-            **kwargs,
         }
+
+        if kwargs:
+            data.update(kwargs)
+
         data = {k: v for k, v in data.items() if v is not None}
 
-        return await self._post("/map", data, timeout)
+        try:
+            response = await self._client.post("/map", content=json.dumps(data), timeout=timeout)
+        except httpx.TimeoutException:
+            raise TimeoutError(timeout)
 
-    async def get_search_context(
-        self,
-        query: str,
-        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "basic",
-        topic: Literal["general", "news", "finance"] = "general",
-        days: int = 7,
-        max_results: int = 5,
-        include_domains: Sequence[str] = None,
-        exclude_domains: Sequence[str] = None,
-        max_tokens: int = 4000,
-        timeout: float = 60,
-        country: str = None,
-        include_favicon: bool = None,
-        **kwargs,
-    ) -> str:
+        if response.status_code == 200:
+            return response.json()
+        else:
+            detail = ""
+            try:
+                detail = response.json().get("detail", {}).get("error", None)
+            except Exception:
+                pass
+
+            if response.status_code == 429:
+                raise UsageLimitExceededError(detail)
+            elif response.status_code in [403,432,433]:
+                raise ForbiddenError(detail)
+            elif response.status_code == 401:
+                raise InvalidAPIKeyError(detail)
+            elif response.status_code == 400:
+                raise BadRequestError(detail)
+            else:
+                raise response.raise_for_status()
+
+    async def map(self,
+                    url: str,
+                    max_depth: int = None,
+                    max_breadth: int = None,
+                    limit: int = None,
+                    instructions: str = None,
+                    select_paths: Sequence[str] = None,
+                    select_domains: Sequence[str] = None,
+                    exclude_paths: Sequence[str] = None,
+                    exclude_domains: Sequence[str] = None,
+                    allow_external: bool = None,
+                    include_images: bool = None,
+                    timeout: float = 150,
+                    include_usage: bool = None,
+                    **kwargs
+                    ) -> dict:
+        """
+        Combined map method.
+
+        """
+        response_dict = await self._map(url,
+                                    max_depth=max_depth,
+                                    max_breadth=max_breadth,
+                                    limit=limit,
+                                    instructions=instructions,
+                                    select_paths=select_paths,
+                                    select_domains=select_domains,
+                                    exclude_paths=exclude_paths,
+                                    exclude_domains=exclude_domains,
+                                    allow_external=allow_external,
+                                    include_images=include_images,
+                                    timeout=timeout,
+                                    include_usage=include_usage,
+                                    **kwargs)
+
+        return response_dict
+
+    async def get_search_context(self,
+                                 query: str,
+                                 search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "basic",
+                                 topic: Literal["general", "news", "finance"] = "general",
+                                 days: int = 7,
+                                 max_results: int = 5,
+                                 include_domains: Sequence[str] = None,
+                                 exclude_domains: Sequence[str] = None,
+                                 max_tokens: int = 4000,
+                                 timeout: float = 60,
+                                 country: str = None,
+                                 include_favicon: bool = None,
+                                 **kwargs,  # Accept custom arguments
+                                 ) -> str:
         """
         Get the search context for a query. Useful for getting only related content from retrieved websites
         without having to deal with context extraction and limitation yourself.
 
-        Args:
-            max_tokens: The maximum number of tokens to return (based on openai token compute). Defaults to 4000.
+        max_tokens: The maximum number of tokens to return (based on openai token compute). Defaults to 4000.
 
-        Returns:
-            A string of JSON containing the search context up to context limit.
+        Returns a string of JSON containing the search context up to context limit.
         """
-        response_dict = await self.search(
-            query,
-            search_depth=search_depth,
-            topic=topic,
-            days=days,
-            max_results=max_results,
-            include_domains=include_domains,
-            exclude_domains=exclude_domains,
-            include_answer=False,
-            include_raw_content=False,
-            include_images=False,
-            timeout=timeout,
-            country=country,
-            include_favicon=include_favicon,
-            **kwargs,
-        )
+        timeout = min(timeout, 120)
+        response_dict = await self._search(query,
+                                           search_depth=search_depth,
+                                           topic=topic,
+                                           days=days,
+                                           max_results=max_results,
+                                           include_domains=include_domains,
+                                           exclude_domains=exclude_domains,
+                                           include_answer=False,
+                                           include_raw_content=False,
+                                           include_images=False,
+                                           timeout = timeout,
+                                           country=country,
+                                           include_favicon=include_favicon,
+                                           **kwargs,
+                                           )
         sources = response_dict.get("results", [])
         context = [{"url": source["url"], "content": source["content"]} for source in sources]
         return json.dumps(get_max_items_from_list(context, max_tokens))
 
-    async def qna_search(
-        self,
-        query: str,
-        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
-        topic: Literal["general", "news", "finance"] = "general",
-        days: int = 7,
-        max_results: int = 5,
-        include_domains: Sequence[str] = None,
-        exclude_domains: Sequence[str] = None,
-        timeout: float = 60,
-        country: str = None,
-        include_favicon: bool = None,
-        **kwargs,
-    ) -> str:
-        """Q&A search method. Search depth is advanced by default to get the best answer."""
-        response_dict = await self.search(
-            query,
-            search_depth=search_depth,
-            topic=topic,
-            days=days,
-            max_results=max_results,
-            include_domains=include_domains,
-            exclude_domains=exclude_domains,
-            include_raw_content=False,
-            include_images=False,
-            include_answer=True,
-            timeout=timeout,
-            country=country,
-            include_favicon=include_favicon,
-            **kwargs,
-        )
+    async def qna_search(self,
+                         query: str,
+                         search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
+                         topic: Literal["general", "news", "finance"] = "general",
+                         days: int = 7,
+                         max_results: int = 5,
+                         include_domains: Sequence[str] = None,
+                         exclude_domains: Sequence[str] = None,
+                         timeout: float = 60,
+                         country: str = None,
+                         include_favicon: bool = None,
+                         **kwargs,  # Accept custom arguments
+                         ) -> str:
+        """
+        Q&A search method. Search depth is advanced by default to get the best answer.
+        """
+        timeout = min(timeout, 120)
+        response_dict = await self._search(query,
+                                           search_depth=search_depth,
+                                           topic=topic,
+                                           days=days,
+                                           max_results=max_results,
+                                           include_domains=include_domains,
+                                           exclude_domains=exclude_domains,
+                                           include_raw_content=False,
+                                           include_images=False,
+                                           include_answer=True,
+                                           timeout = timeout,
+                                           country=country,
+                                           include_favicon=include_favicon,
+                                           **kwargs,
+                                           )
         return response_dict.get("answer", "")
 
-    async def get_company_info(
-        self,
-        query: str,
-        search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
-        max_results: int = 5,
-        timeout: float = 60,
-        country: str = None,
-    ) -> Sequence[dict]:
-        """Company information search method. Search depth is advanced by default to get the best answer."""
-        async def perform_search(topic: str) -> dict:
-            return await self.search(
-                query,
-                search_depth=search_depth,
-                topic=topic,
-                max_results=max_results,
-                include_answer=False,
-                timeout=timeout,
-                country=country,
-            )
+    async def get_company_info(self,
+                               query: str,
+                               search_depth: Literal["basic", "advanced", "fast", "ultra-fast"] = "advanced",
+                               max_results: int = 5,
+                               timeout: float = 60,
+                               country: str = None,
+                               ) -> Sequence[dict]:
+        """ Company information search method. Search depth is advanced by default to get the best answer. """
+        timeout = min(timeout, 120)
 
-        results = await asyncio.gather(*[perform_search(topic) for topic in self._company_info_tags])
+        async def _perform_search(topic: str):
+            return await self._search(query,
+                                      search_depth=search_depth,
+                                      topic=topic,
+                                      max_results=max_results,
+                                      include_answer=False,
+                                      timeout = timeout,
+                                      country=country)
 
         all_results = []
-        for data in results:
-            all_results.extend(data.get("results", []))
+        for data in await asyncio.gather(*[_perform_search(topic) for topic in self._company_info_tags]):
+            if "results" in data:
+                all_results.extend(data["results"])
 
-        return sorted(all_results, key=lambda x: x["score"], reverse=True)[:max_results]
+        # Sort all the results by score in descending order and take the top 'max_results' items
+        sorted_results = sorted(all_results, key=lambda x: x["score"], reverse=True)[:max_results]
 
-    def _handle_stream_error(self, status_code: int, error_text: str) -> None:
-        """Handle error responses during streaming."""
-        if status_code == 429:
-            raise UsageLimitExceededError(error_text)
-        if status_code in (403, 432, 433):
-            raise ForbiddenError(error_text)
-        if status_code == 401:
-            raise InvalidAPIKeyError(error_text)
-        if status_code == 400:
-            raise BadRequestError(error_text)
-        raise Exception(f"Error {status_code}: {error_text}")
+        return sorted_results
 
-    async def _research_stream(
-        self,
-        data: dict,
-        timeout: Optional[float],
-    ) -> AsyncGenerator[bytes, None]:
-        """Stream research results from the API."""
-        try:
-            async with self._client.stream(
-                "POST",
-                "/research",
-                content=json.dumps(data),
-                timeout=timeout,
-            ) as response:
-                if response.status_code != 200:
+    def _research(self,
+                  input: str,
+                  model: Literal["mini", "pro", "auto"] = None,
+                  output_schema: dict = None,
+                  stream: bool = False,
+                  citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
+                  timeout: Optional[float] = None,
+                  **kwargs
+                  ) -> Union[AsyncGenerator[bytes, None], Awaitable[dict]]:
+        """
+        Internal research method to send the request to the API.
+        """
+        data = {
+            "input": input,
+            "model": model,
+            "output_schema": output_schema,
+            "stream": stream,
+            "citation_format": citation_format,
+        }
+
+        data = {k: v for k, v in data.items() if v is not None}
+
+        if kwargs:
+            data.update(kwargs)
+
+        if stream:
+            async def stream_generator() -> AsyncGenerator[bytes, None]:
+                try:
+                    async with self._client.stream(
+                        "POST",
+                        "/research",
+                        content=json.dumps(data),
+                        timeout=timeout
+                    ) as response:
+                        if response.status_code != 200:
+                            try:
+                                error_text = await response.aread()
+                                error_text = error_text.decode('utf-8') if isinstance(error_text, bytes) else error_text
+                            except Exception:
+                                error_text = "Unknown error"
+
+                            if response.status_code == 429:
+                                raise UsageLimitExceededError(error_text)
+                            elif response.status_code in [403,432,433]:
+                                raise ForbiddenError(error_text)
+                            elif response.status_code == 401:
+                                raise InvalidAPIKeyError(error_text)
+                            elif response.status_code == 400:
+                                raise BadRequestError(error_text)
+                            else:
+                                raise Exception(f"Error {response.status_code}: {error_text}")
+
+                        async for chunk in response.aiter_bytes():
+                            if chunk:
+                                yield chunk
+                except httpx.TimeoutException:
+                    raise TimeoutError(timeout)
+                except Exception as e:
+                    raise Exception(f"Error during research stream: {str(e)}")
+
+            return stream_generator()
+        else:
+            async def _make_request():
+                try:
+                    response = await self._client.post("/research", content=json.dumps(data), timeout=timeout)
+                except httpx.TimeoutException:
+                    raise TimeoutError(timeout)
+
+                if response.status_code == 200:
+                    return response.json()
+                else:
+                    detail = ""
                     try:
-                        error_bytes = await response.aread()
-                        error_text = error_bytes.decode("utf-8") if isinstance(error_bytes, bytes) else error_bytes
+                        detail = response.json().get("detail", {}).get("error", None)
                     except Exception:
-                        error_text = "Unknown error"
-                    self._handle_stream_error(response.status_code, error_text)
+                        pass
 
-                async for chunk in response.aiter_bytes():
-                    if chunk:
-                        yield chunk
-        except httpx.TimeoutException:
-            raise TimeoutError(timeout)
+                    if response.status_code == 429:
+                        raise UsageLimitExceededError(detail)
+                    elif response.status_code in [403,432,433]:
+                        raise ForbiddenError(detail)
+                    elif response.status_code == 401:
+                        raise InvalidAPIKeyError(detail)
+                    elif response.status_code == 400:
+                        raise BadRequestError(detail)
+                    else:
+                        raise response.raise_for_status()
 
-    async def research(
-        self,
-        input: str,
-        model: Literal["mini", "pro", "auto"] = None,
-        output_schema: dict = None,
-        stream: bool = False,
-        citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
-        timeout: Optional[float] = None,
-        **kwargs,
-    ) -> Union[dict, AsyncGenerator[bytes, None]]:
+            return _make_request()
+
+    async def research(self,
+                       input: str,
+                       model: Literal["mini", "pro", "auto"] = None,
+                       output_schema: dict = None,
+                       stream: bool = False,
+                       citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
+                       timeout: Optional[float] = None,
+                       **kwargs
+                       ) -> Union[dict, AsyncGenerator[bytes, None]]:
         """
         Research method to create a research task.
 
@@ -442,22 +733,23 @@ class AsyncTavilyClient:
             When stream=False: dict - the response dictionary.
             When stream=True: AsyncGenerator[bytes, None] - iterate over this to get streaming chunks.
         """
-        data = {
-            "input": input,
-            "model": model,
-            "output_schema": output_schema,
-            "stream": stream,
-            "citation_format": citation_format,
-            **kwargs,
-        }
-        data = {k: v for k, v in data.items() if v is not None}
-
+        result = self._research(
+                input=input,
+                model=model,
+                output_schema=output_schema,
+                stream=stream,
+                citation_format=citation_format,
+                timeout=timeout,
+                **kwargs
+        )
         if stream:
-            return self._research_stream(data, timeout)
+            return result # Don't await the result, it's an AsyncGenerator that will be lazy and only execute when iterated over with async for
+        else:
+            return await result
 
-        return await self._post("/research", data, timeout)
-
-    async def get_research(self, request_id: str) -> dict:
+    async def get_research(self,
+                           request_id: str
+                           ) -> dict:
         """
         Get research results by request_id.
 
@@ -467,9 +759,28 @@ class AsyncTavilyClient:
         Returns:
             dict: Research response containing request_id, created_at, completed_at, status, content, and sources.
         """
-        response = await self._client.get(f"/research/{request_id}")
+        try:
+            response = await self._client.get(f"/research/{request_id}")
+        except Exception as e:
+            raise Exception(f"Error getting research: {e}")
 
         if response.status_code in (200, 202):
-            return response.json()
+            data = response.json()
+            return data
+        else:
+            detail = ""
+            try:
+                detail = response.json().get("detail", {}).get("error", None)
+            except Exception:
+                pass
 
-        self._handle_error_response(response)
+            if response.status_code == 429:
+                raise UsageLimitExceededError(detail)
+            elif response.status_code in [403,432,433]:
+                raise ForbiddenError(detail)
+            elif response.status_code == 401:
+                raise InvalidAPIKeyError(detail)
+            elif response.status_code == 400:
+                raise BadRequestError(detail)
+            else:
+                raise response.raise_for_status()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -11,7 +11,10 @@ def set_api_key():
     old_key = os.getenv("TAVILY_API_KEY")
     os.environ["TAVILY_API_KEY"] = "test_api_key"
     yield
-    os.environ["TAVILY_API_KEY"] = old_key
+    if old_key is not None:
+        os.environ["TAVILY_API_KEY"] = old_key
+    elif "TAVILY_API_KEY" in os.environ:
+        del os.environ["TAVILY_API_KEY"]
 
 @pytest.fixture
 def clear_api_key():

--- a/tests/test_session_pooling.py
+++ b/tests/test_session_pooling.py
@@ -1,0 +1,152 @@
+"""
+Tests for session pooling functionality in both sync and async clients.
+"""
+import asyncio
+import pytest
+
+import tavily.tavily as sync_tavily
+import tavily.async_tavily as async_tavily
+from tests.request_intercept import intercept_requests, clear_interceptor
+
+
+dummy_response = {
+    "query": "test",
+    "results": [{"title": "Test", "url": "https://test.com", "content": "Test content", "score": 0.99}],
+    "response_time": 0.1
+}
+
+
+# =============================================================================
+# SYNC CLIENT TESTS
+# =============================================================================
+
+class TestSyncSessionPooling:
+    """Test sync client session pooling and lifecycle."""
+
+    @pytest.fixture
+    def interceptor(self):
+        yield intercept_requests(sync_tavily)
+        clear_interceptor(sync_tavily)
+
+    def test_context_manager(self, interceptor):
+        """Test that sync client works with context manager."""
+        interceptor.set_response(200, json=dummy_response)
+
+        with sync_tavily.TavilyClient(api_key="tvly-test") as client:
+            response = client.search("test query")
+            assert response["results"][0]["title"] == "Test"
+
+    def test_close_method(self, interceptor):
+        """Test that close() method works without error."""
+        interceptor.set_response(200, json=dummy_response)
+
+        client = sync_tavily.TavilyClient(api_key="tvly-test")
+        response = client.search("test query")
+        assert response["results"][0]["title"] == "Test"
+
+        # close() should not raise
+        client.close()
+
+    def test_multiple_sequential_requests(self, interceptor):
+        """Test that multiple requests work with same client (connection reuse)."""
+        interceptor.set_response(200, json=dummy_response)
+
+        client = sync_tavily.TavilyClient(api_key="tvly-test")
+
+        # Make multiple requests with same client
+        for i in range(3):
+            response = client.search(f"test query {i}")
+            assert response["results"][0]["title"] == "Test"
+
+        client.close()
+
+    def test_context_manager_multiple_requests(self, interceptor):
+        """Test multiple requests within context manager."""
+        interceptor.set_response(200, json=dummy_response)
+
+        with sync_tavily.TavilyClient(api_key="tvly-test") as client:
+            for i in range(3):
+                response = client.search(f"test query {i}")
+                assert response["results"][0]["title"] == "Test"
+
+
+# =============================================================================
+# ASYNC CLIENT TESTS
+# =============================================================================
+
+class TestAsyncSessionPooling:
+    """Test async client session pooling and lifecycle."""
+
+    @pytest.fixture
+    def interceptor(self):
+        yield intercept_requests(async_tavily)
+        clear_interceptor(async_tavily)
+
+    def test_context_manager(self, interceptor):
+        """Test that async client works with async context manager."""
+        interceptor.set_response(200, json=dummy_response)
+
+        async def run():
+            async with async_tavily.AsyncTavilyClient(api_key="tvly-test") as client:
+                response = await client.search("test query")
+                assert response["results"][0]["title"] == "Test"
+
+        asyncio.run(run())
+
+    def test_close_method(self, interceptor):
+        """Test that close() method works without error."""
+        interceptor.set_response(200, json=dummy_response)
+
+        async def run():
+            client = async_tavily.AsyncTavilyClient(api_key="tvly-test")
+            response = await client.search("test query")
+            assert response["results"][0]["title"] == "Test"
+
+            # close() should not raise
+            await client.close()
+
+        asyncio.run(run())
+
+    def test_multiple_sequential_requests(self, interceptor):
+        """Test that multiple requests work with same client (connection reuse)."""
+        interceptor.set_response(200, json=dummy_response)
+
+        async def run():
+            client = async_tavily.AsyncTavilyClient(api_key="tvly-test")
+
+            # Make multiple requests with same client
+            for i in range(3):
+                response = await client.search(f"test query {i}")
+                assert response["results"][0]["title"] == "Test"
+
+            await client.close()
+
+        asyncio.run(run())
+
+    def test_context_manager_multiple_requests(self, interceptor):
+        """Test multiple requests within async context manager."""
+        interceptor.set_response(200, json=dummy_response)
+
+        async def run():
+            async with async_tavily.AsyncTavilyClient(api_key="tvly-test") as client:
+                for i in range(3):
+                    response = await client.search(f"test query {i}")
+                    assert response["results"][0]["title"] == "Test"
+
+        asyncio.run(run())
+
+    def test_concurrent_requests_same_client(self, interceptor):
+        """Test concurrent requests using same client."""
+        interceptor.set_response(200, json=dummy_response)
+
+        async def run():
+            async with async_tavily.AsyncTavilyClient(api_key="tvly-test") as client:
+                # Run multiple searches concurrently
+                tasks = [client.search(f"query {i}") for i in range(3)]
+                results = await asyncio.gather(*tasks)
+
+                assert len(results) == 3
+                for result in results:
+                    assert result["results"][0]["title"] == "Test"
+
+        asyncio.run(run())


### PR DESCRIPTION
## Summary
- Add persistent `httpx.AsyncClient` instance for connection pooling in `AsyncTavilyClient`
- Add `close()` method and async context manager support (`__aenter__`, `__aexit__`)
- Enable TCP connection reuse across multiple API requests for improved performance
- Add comprehensive test suite for session pooling edge cases (`tests/test_session_pooling.py`)
- Bump version to 0.7.21

## Changes
The async client now maintains a single `httpx.AsyncClient` instance instead of creating a new client per request. This enables HTTP connection reuse (avoiding TCP/TLS handshake overhead on subsequent requests).

### Usage
```python
# Option 1: Context manager (recommended)
async with AsyncTavilyClient(api_key="...") as client:
    result = await client.search("query")
    # Connection is reused for additional requests
    result2 = await client.search("another query")

# Option 2: Manual cleanup
client = AsyncTavilyClient(api_key="...")
try:
    result = await client.search("query")
finally:
    await client.close()
```

## Test plan
- [x] All existing unit tests pass (30 tests)
- [x] New session pooling tests pass (`tests/test_session_pooling.py`)
- [x] Manual testing with real API calls

Linear: TAV-4105

🤖 Generated with [Claude Code](https://claude.com/claude-code)