### PR TITLE
fix: make deprecated Client initializer backward-compatible

### DIFF
--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -739,7 +739,15 @@ class Client(TavilyClient):
     WARNING! This class is deprecated. Please use TavilyClient instead.
     """
 
-    def __init__(self, kwargs):
+    def __init__(self, kwargs=None, **legacy_kwargs):
         warnings.warn("Client is deprecated, please use TavilyClient instead",
                       DeprecationWarning, stacklevel=2)
-        super().__init__(kwargs)
+
+        if isinstance(kwargs, dict):
+            init_kwargs = {**kwargs, **legacy_kwargs}
+        elif kwargs is not None:
+            init_kwargs = {"api_key": kwargs, **legacy_kwargs}
+        else:
+            init_kwargs = legacy_kwargs
+
+        super().__init__(**init_kwargs)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -51,3 +51,17 @@ def test_invalid_api_key():
     with pytest.raises(InvalidAPIKeyError):
         print(async_tavily.httpx.AsyncClient.post)
         print(asyncio.run(async_tavily.AsyncTavilyClient(api_key="invalid_api_key").search("What is Tavily?")))
+
+
+def test_deprecated_client_accepts_keyword_args():
+    with pytest.warns(DeprecationWarning):
+        client = sync_tavily.Client(api_key="tvly-test")
+    assert client.api_key == "tvly-test"
+    client.close()
+
+
+def test_deprecated_client_accepts_legacy_dict_kwargs():
+    with pytest.warns(DeprecationWarning):
+        client = sync_tavily.Client({"api_key": "tvly-test"})
+    assert client.api_key == "tvly-test"
+    client.close()


### PR DESCRIPTION
## What changed
- Fixed the deprecated `Client` initializer so it correctly forwards parameters to `TavilyClient`.
- Added backward-compatible handling for three call styles:
  - `Client(api_key="...")`
  - `Client({"api_key": "..."})`
  - `Client("...")`
- Added regression tests covering keyword-arg and legacy-dict initialization paths.

## Why
- The deprecated `Client` class currently passes a single positional argument directly to `TavilyClient`, which can mis-handle initialization data (for example, passing a dict as the API key).
- This change preserves backwards compatibility while ensuring deprecated usage remains functional and predictable during migration to `TavilyClient`.

## Testing
- ✅ `source .venv/bin/activate && pytest -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to argument parsing in a deprecated wrapper and adds regression tests; no core request/response logic is modified.
> 
> **Overview**
> Fixes the deprecated `Client` constructor to correctly forward initialization params to `TavilyClient` across legacy usage patterns (dict, keyword args, or a positional API key string).
> 
> Adds regression tests ensuring `Client` still emits a `DeprecationWarning` while properly setting `api_key` when initialized via keyword args or a legacy dict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dab217efeb2b8c39fbd56aa3391d899c87b2a15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->