### PR TITLE
docs: clarify header defaults for custom session/client injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,10 @@ response = await client.search("latest AI research")
 **Key behaviors:**
 - If a custom session/client is provided, `api_key` is optional
 - Custom session headers take precedence over SDK defaults (e.g., your `Authorization` won't be overwritten)
+- If you provide a custom session/client and also pass `api_key`, Tavily fills in any missing default headers on that object, including `Authorization`, `Content-Type`, and `X-Client-Source`
 - Custom session proxies take precedence over SDK proxy settings
 - The SDK will **not** close externally-provided sessions — you manage the lifecycle
+- If you want Tavily defaults isolated from other traffic, use a dedicated session/client for Tavily requests
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- clarify README behavior for custom session/client injection when `api_key` is also provided
- document that Tavily fills in missing default headers on the externally-owned object
- recommend a dedicated session/client when callers want Tavily defaults isolated from other traffic

## Why
The current implementation and tests already support this behavior, but the README only says that custom headers take precedence and that external sessions are user-managed. This small clarification makes the current contract more explicit for integrators using shared HTTP clients.

## Testing
- [x] `pytest -q tests/test_custom_session.py tests/test_session_pooling.py`
- [x] README-only change; no runtime behavior changed

Closes #164
