### PR TITLE
fix(async): preserve typed errors in research stream mode

### DIFF
--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -723,8 +723,11 @@ class AsyncTavilyClient:
                                 yield chunk
                 except httpx.TimeoutException:
                     raise TimeoutError(timeout)
+                except (UsageLimitExceededError, ForbiddenError, InvalidAPIKeyError, BadRequestError, TimeoutError):
+                    # Preserve Tavily-specific error types for callers in streaming mode.
+                    raise
                 except Exception as e:
-                    raise Exception(f"Error during research stream: {str(e)}")
+                    raise Exception(f"Error during research stream: {str(e)}") from e
 
             return stream_generator()
         else:

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,5 +1,9 @@
 import asyncio
 
+import pytest
+
+from tavily.errors import UsageLimitExceededError
+
 BASE_URL = "https://api.tavily.com"
 
 dummy_queued_response = {
@@ -146,4 +150,20 @@ def test_async_get_research(async_interceptor, async_client):
     response = asyncio.run(async_client.get_research("test-request-123"))
     request = async_interceptor.get_request()
     validate_get_research(request, response)
+
+
+def test_async_research_stream_preserves_usage_limit_error(async_interceptor, async_client):
+    async_interceptor.set_response(429, json={"detail": {"error": "quota exceeded"}})
+
+    async def run_test():
+        stream = await async_client.research(
+            input="Research the latest developments in AI",
+            stream=True,
+        )
+
+        with pytest.raises(UsageLimitExceededError, match="quota exceeded"):
+            async for _ in stream:
+                pass
+
+    asyncio.run(run_test())
 


### PR DESCRIPTION
## What changed
- Fixed `AsyncTavilyClient` research streaming error handling so Tavily-specific exceptions are no longer wrapped into a generic `Exception`.
- Added explicit pass-through for:
  - `UsageLimitExceededError`
  - `ForbiddenError`
  - `InvalidAPIKeyError`
  - `BadRequestError`
  - `TimeoutError`
- Added a regression test that verifies async streaming research preserves `UsageLimitExceededError` on HTTP 429.

## Insight / Why this matters
In async stream mode, `_research(..., stream=True)` raised domain-specific exceptions for non-200 responses, but then immediately caught them with a broad `except Exception` and re-raised a generic error.

That made stream-mode error handling inconsistent with non-stream mode and with the sync client path. It is easy to miss because happy-path stream tests pass, while typed error handling only appears in failure scenarios.

This change preserves typed exceptions, so callers can implement correct retry/backoff and user messaging logic based on error class instead of brittle string parsing.

## Practical gain / Why this matters
- Improves production reliability for streaming consumers.
- Enables precise client behavior (e.g., handle quota limits differently from auth failures).
- Reduces integration bugs caused by generic exception wrapping.

## Why
- Align async streaming behavior with the rest of the SDK’s error model.
- Keep failures actionable for SDK users in real integrations.

## Testing
- ✅ `pytest -q tests/test_research.py`
- ✅ `pytest -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes exception propagation in async streaming mode, which can affect downstream error handling, but is limited in scope and covered by a targeted regression test.
> 
> **Overview**
> Async `research(..., stream=True)` now **preserves Tavily-specific error classes** (`UsageLimitExceededError`, `ForbiddenError`, `InvalidAPIKeyError`, `BadRequestError`, `TimeoutError`) instead of catching them and rethrowing a generic `Exception`; unexpected errors are still wrapped but now use exception chaining (`raise ... from e`).
> 
> Adds a regression test ensuring a `429` response in streaming mode raises `UsageLimitExceededError` with the server-provided message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9958f4785202844730e490c8b59a81f6c87b8f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->