### PR TITLE
feat: accept Pydantic BaseModel as output_schema in research()

### DIFF
--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -5,7 +5,7 @@ from typing import Literal, Sequence, Optional, List, Union, AsyncGenerator, Awa
 
 import httpx
 
-from .utils import get_max_items_from_list
+from .utils import get_max_items_from_list, resolve_output_schema
 from .errors import UsageLimitExceededError, InvalidAPIKeyError, MissingAPIKeyError, BadRequestError, ForbiddenError, TimeoutError
 
 
@@ -667,7 +667,7 @@ class AsyncTavilyClient:
     def _research(self,
                   input: str,
                   model: Literal["mini", "pro", "auto"] = None,
-                  output_schema: dict = None,
+                  output_schema: Union[dict, type] = None,
                   stream: bool = False,
                   citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
                   timeout: Optional[float] = None,
@@ -676,6 +676,7 @@ class AsyncTavilyClient:
         """
         Internal research method to send the request to the API.
         """
+        output_schema = resolve_output_schema(output_schema)
         data = {
             "input": input,
             "model": model,
@@ -759,7 +760,7 @@ class AsyncTavilyClient:
     async def research(self,
                        input: str,
                        model: Literal["mini", "pro", "auto"] = None,
-                       output_schema: dict = None,
+                       output_schema: Union[dict, type] = None,
                        stream: bool = False,
                        citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
                        timeout: Optional[float] = None,
@@ -771,7 +772,8 @@ class AsyncTavilyClient:
         Args:
             input: The research task description (required).
             model: Research depth - must be either 'mini', 'pro', or 'auto'.
-            output_schema: Schema for the 'structured_output' response format (JSON Schema dict).
+            output_schema: Schema for structured output. Accepts a JSON Schema dict or a
+                Pydantic BaseModel subclass (converted automatically).
             stream: Whether to stream the research task.
             citation_format: Citation format - must be either 'numbered', 'mla', 'apa', or 'chicago'.
             timeout: Optional HTTP request timeout in seconds.

--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -3,7 +3,7 @@ import json
 import os
 import warnings
 from typing import Literal, Sequence, Optional, List, Union, Generator
-from .utils import get_max_items_from_list
+from .utils import get_max_items_from_list, resolve_output_schema
 from .errors import UsageLimitExceededError, InvalidAPIKeyError, MissingAPIKeyError, BadRequestError, ForbiddenError, TimeoutError
 
 class TavilyClient:
@@ -611,7 +611,7 @@ class TavilyClient:
     def _research(self,
                   input: str,
                   model: Literal["mini", "pro", "auto"] = None,
-                  output_schema: dict = None,
+                  output_schema: Union[dict, type] = None,
                   stream: bool = False,
                   citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
                   timeout: Optional[float] = None,
@@ -620,6 +620,7 @@ class TavilyClient:
         """
         Internal research method to send the request to the API.
         """
+        output_schema = resolve_output_schema(output_schema)
         data = {
             "input": input,
             "model": model,
@@ -707,7 +708,7 @@ class TavilyClient:
     def research(self,
                  input: str,
                  model: Literal["mini", "pro", "auto"] = None,
-                 output_schema: dict = None,
+                 output_schema: Union[dict, type] = None,
                  stream: bool = False,
                  citation_format: Literal["numbered", "mla", "apa", "chicago"] = "numbered",
                  timeout: Optional[float] = None,
@@ -715,11 +716,12 @@ class TavilyClient:
                  ) -> Union[dict, Generator[bytes, None, None]]:
         """
         Research method to create a research task.
-        
+
         Args:
             input: The research task or question to investigate (required).
             model: The model used by the research agent - must be either 'mini', 'pro', or 'auto'.
-            output_schema: Schema for the 'structured_output' response format (JSON Schema dict).
+            output_schema: Schema for structured output. Accepts a JSON Schema dict or a
+                Pydantic BaseModel subclass (converted automatically).
             stream: Whether to stream the research task.
             citation_format: Citation format - must be either 'numbered', 'mla', 'apa', or 'chicago'.
             timeout: Optional HTTP request timeout in seconds. 

--- a/tavily/utils.py
+++ b/tavily/utils.py
@@ -1,7 +1,42 @@
 import tiktoken
 import json
-from typing import Sequence, List, Dict
+from typing import Sequence, List, Dict, Union
 from .config import DEFAULT_MODEL_ENCODING, DEFAULT_MAX_TOKENS
+
+
+def resolve_output_schema(output_schema) -> Union[dict, None]:
+    """Convert a Pydantic BaseModel subclass to a Tavily-compatible JSON schema dict.
+
+    Tavily's API only accepts 'properties' and 'required' at the top level.
+    This strips the full Pydantic JSON schema down to those keys and resolves
+    any $ref/$defs references inline so nested models are inlined.
+
+    Plain dicts are passed through unchanged. If pydantic is not installed
+    and a non-dict is passed, it is returned as-is.
+    """
+    if output_schema is None:
+        return None
+    try:
+        from pydantic import BaseModel
+        if isinstance(output_schema, type) and issubclass(output_schema, BaseModel):
+            schema = output_schema.model_json_schema()
+            defs = schema.get("$defs", {})
+
+            def _resolve(obj):
+                if isinstance(obj, dict):
+                    if "$ref" in obj:
+                        ref_name = obj["$ref"].split("/")[-1]
+                        return _resolve(defs[ref_name])
+                    return {k: _resolve(v) for k, v in obj.items() if k != "title"}
+                if isinstance(obj, list):
+                    return [_resolve(i) for i in obj]
+                return obj
+
+            resolved = _resolve(schema)
+            return {k: resolved[k] for k in ("properties", "required") if k in resolved}
+    except ImportError:
+        pass
+    return output_schema
 
 
 def get_total_tokens_from_string(string: str, encoding_name: str = DEFAULT_MODEL_ENCODING) -> int:

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,4 +1,6 @@
 import asyncio
+from pydantic import BaseModel, Field
+from typing import List
 
 BASE_URL = "https://api.tavily.com"
 
@@ -146,4 +148,65 @@ def test_async_get_research(async_interceptor, async_client):
     response = asyncio.run(async_client.get_research("test-request-123"))
     request = async_interceptor.get_request()
     validate_get_research(request, response)
+
+
+# --- Pydantic output_schema tests ---
+
+class KeyPoint(BaseModel):
+    point: str = Field(description="A key finding")
+
+class ResearchReport(BaseModel):
+    summary: str = Field(description="Executive summary")
+    key_points: List[KeyPoint] = Field(description="List of key findings")
+
+expected_pydantic_schema = {
+    "properties": {
+        "summary": {"type": "string", "description": "Executive summary"},
+        "key_points": {
+            "type": "array",
+            "description": "List of key findings",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "point": {"type": "string", "description": "A key finding"}
+                },
+                "required": ["point"]
+            }
+        }
+    },
+    "required": ["summary", "key_points"]
+}
+
+def test_sync_research_pydantic_schema(sync_interceptor, sync_client):
+    """Passing a Pydantic BaseModel is automatically converted to a Tavily-compatible schema."""
+    sync_interceptor.set_response(200, json=dummy_queued_response)
+    response = sync_client.research(
+        input="Research the latest developments in AI",
+        output_schema=ResearchReport,
+    )
+    request = sync_interceptor.get_request()
+    assert request.json().get("output_schema") == expected_pydantic_schema
+    assert response == dummy_queued_response
+
+def test_async_research_pydantic_schema(async_interceptor, async_client):
+    """Passing a Pydantic BaseModel is automatically converted to a Tavily-compatible schema (async)."""
+    async_interceptor.set_response(200, json=dummy_queued_response)
+    response = asyncio.run(async_client.research(
+        input="Research the latest developments in AI",
+        output_schema=ResearchReport,
+    ))
+    request = async_interceptor.get_request()
+    assert request.json().get("output_schema") == expected_pydantic_schema
+    assert response == dummy_queued_response
+
+def test_sync_research_dict_schema_unchanged(sync_interceptor, sync_client):
+    """Plain dict schemas are passed through unchanged."""
+    plain_schema = {"properties": {"answer": {"type": "string"}}, "required": ["answer"]}
+    sync_interceptor.set_response(200, json=dummy_queued_response)
+    sync_client.research(
+        input="Research the latest developments in AI",
+        output_schema=plain_schema,
+    )
+    request = sync_interceptor.get_request()
+    assert request.json().get("output_schema") == plain_schema
 


### PR DESCRIPTION
## Summary

- `research()` now accepts a Pydantic `BaseModel` subclass as `output_schema` in addition to a plain dict
- A new `resolve_output_schema()` helper in `utils.py` converts the Pydantic schema to what the API accepts: strips disallowed top-level keys (`title`, `type`, `$defs`) and inlines any `$ref` references so nested models work correctly
- Plain dicts are passed through unchanged — fully backward-compatible
- Pydantic remains an optional dependency; the helper falls back gracefully if it's not installed

## Why

The Tavily API only accepts `properties` and `required` at the top level of `output_schema`. Pydantic's `model_json_schema()` produces a richer schema with `$defs`, `title`, `type`, etc., causing a `BadRequestError`. Users had to hand-write the schema dict or manually strip it. This change removes that friction.

**Before:**
```python
output_schema = {
    "properties": {
        "company": {
            "type": "string",
            "description": "The name of the company"
        },
        "key_metrics": {
            "type": "array",
            "description": "List of key performance metrics",
            "items": {"type": "string"}
        },
        "financial_details": {
            "type": "object",
            "description": "Detailed financial breakdown",
            "properties": {
                "operating_income": {
                    "type": "number",
                    "description": "Operating income for the period"
                }
            }
        }
    },
    "required": ["company"]
}
```

**After:**
```python
class FinancialDetails(BaseModel):
    operating_income: float = Field(description="Operating income for the period")

class CompanyReport(BaseModel):
    company: str = Field(description="The name of the company")
    key_metrics: List[str] = Field(description="List of key performance metrics")
    financial_details: FinancialDetails = Field(description="Detailed financial breakdown")

client.research("...", output_schema=CompanyReport)
```

## Testing

- [x] 3 new tests in `tests/test_research.py`: Pydantic model (sync), Pydantic model (async), plain dict unchanged
- [x] All 77 existing tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `output_schema` is serialized and sent to the `/research` API, which could affect structured-output requests if schema conversion is incorrect. Scope is limited to `research()` (sync/async) and is covered by new tests.
> 
> **Overview**
> `research()` (sync and async) now accepts `output_schema` as either a JSON-schema `dict` **or** a Pydantic `BaseModel` subclass, and normalizes it before calling the `/research` endpoint.
> 
> Adds `utils.resolve_output_schema()` to convert Pydantic-generated schemas into the API-accepted shape by *inlining* `$ref`/`$defs` and keeping only top-level `properties`/`required`, while leaving plain dict schemas unchanged and remaining compatible when Pydantic isn’t installed.
> 
> Extends `tests/test_research.py` with coverage for Pydantic-schema conversion (sync/async) and dict passthrough behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b4aefd089375d2568670c61964900dc1cba629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->