### PR TITLE
feat: optional org_id parameter (x-tavily-orgid header)

### DIFF
--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -82,7 +82,7 @@ class AsyncTavilyClient:
             **({"X-Tavily-Access-Mode": "keyless"} if self._keyless else {}),
             "X-Client-Source": client_source_header,
             **({"X-Project-ID": tavily_project} if tavily_project else {}),
-            **({"x-tavily-orgid": tavily_org} if tavily_org else {}),
+            **({"X-Tavily-Orgid": tavily_org} if tavily_org else {}),
             **({"X-Session-Id": session_id} if session_id else {}),
             **({"X-Human-Id": human_id} if human_id else {}),
             **({"X-Client-Name": client_name} if client_name else {}),

--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -50,6 +50,7 @@ class AsyncTavilyClient:
                  api_base_url: Optional[str] = None,
                  client_source: Optional[str] = None,
                  project_id: Optional[str] = None,
+                 org_id: Optional[str] = None,
                  session_id: Optional[str] = None,
                  human_id: Optional[str] = None,
                  client_name: Optional[str] = None,
@@ -62,6 +63,7 @@ class AsyncTavilyClient:
         api_key = api_key or None
 
         tavily_project = project_id or os.getenv("TAVILY_PROJECT")
+        tavily_org = org_id or os.getenv("TAVILY_ORG_ID")
 
         self._api_base_url = api_base_url or "https://api.tavily.com"
         self._company_info_tags = company_info_tags
@@ -80,6 +82,7 @@ class AsyncTavilyClient:
             **({"X-Tavily-Access-Mode": "keyless"} if self._keyless else {}),
             "X-Client-Source": client_source_header,
             **({"X-Project-ID": tavily_project} if tavily_project else {}),
+            **({"x-tavily-orgid": tavily_org} if tavily_org else {}),
             **({"X-Session-Id": session_id} if session_id else {}),
             **({"X-Human-Id": human_id} if human_id else {}),
             **({"X-Client-Name": client_name} if client_name else {}),

--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -85,7 +85,7 @@ class TavilyClient:
             **({"X-Tavily-Access-Mode": "keyless"} if self._keyless else {}),
             "X-Client-Source": client_source_header,
             **({"X-Project-ID": tavily_project} if tavily_project else {}),
-            **({"x-tavily-orgid": tavily_org} if tavily_org else {}),
+            **({"X-Tavily-Orgid": tavily_org} if tavily_org else {}),
             **({"X-Session-Id": session_id} if session_id else {}),
             **({"X-Human-Id": human_id} if human_id else {}),
             **({"X-Client-Name": client_name} if client_name else {}),

--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -49,6 +49,7 @@ class TavilyClient:
         api_base_url: Optional[str] = None,
         client_source: Optional[str] = None,
         project_id: Optional[str] = None,
+        org_id: Optional[str] = None,
         session_id: Optional[str] = None,
         human_id: Optional[str] = None,
         client_name: Optional[str] = None,
@@ -66,6 +67,7 @@ class TavilyClient:
 
         resolved_proxies = {k: v for k, v in resolved_proxies.items() if v} or None
         tavily_project = project_id or os.getenv("TAVILY_PROJECT")
+        tavily_org = org_id or os.getenv("TAVILY_ORG_ID")
 
         self.base_url = api_base_url or "https://api.tavily.com"
         self.api_key = api_key
@@ -83,6 +85,7 @@ class TavilyClient:
             **({"X-Tavily-Access-Mode": "keyless"} if self._keyless else {}),
             "X-Client-Source": client_source_header,
             **({"X-Project-ID": tavily_project} if tavily_project else {}),
+            **({"x-tavily-orgid": tavily_org} if tavily_org else {}),
             **({"X-Session-Id": session_id} if session_id else {}),
             **({"X-Human-Id": human_id} if human_id else {}),
             **({"X-Client-Name": client_name} if client_name else {}),


### PR DESCRIPTION
## What

Adds an optional `org_id` parameter to `TavilyClient` and `AsyncTavilyClient` (with a `TAVILY_ORG_ID` environment variable fallback). When set, the client attaches an `x-tavily-orgid` header to every request.

## Why

This header lets the edge (WAF) apply per-organization rate limits by tier, instead of per key. SDK users just pass their org id once and the header is sent automatically; nothing changes for callers who don't set it.

## How

Mirrors the existing `project_id` / `X-Project-ID` handling: resolve `org_id` (or `TAVILY_ORG_ID`), and conditionally add the header to the client's default headers. The header is only sent when an org id is provided.

## Test

- `py_compile` passes for both clients.
- Verified the header is present when `org_id` is set (sync and async) and absent when it isn't.