### PR TITLE
chore: bump version to 0.7.26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='tavily-python',
-    version='0.7.25',
+    version='0.7.26',
     url='https://github.com/tavily-ai/tavily-python',
     author='Tavily AI',
     author_email='support@tavily.com',


### PR DESCRIPTION
Bumps the package version to 0.7.26 to release the optional `org_id` parameter / `X-Tavily-Orgid` header added in #175 (that PR added the feature but did not bump the version).