### PR TITLE
feat: add opt-in retries honoring Retry-After

### DIFF
--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -16,6 +16,7 @@ from .errors import (
     TavilyKeylessLimitError,
     KeylessUnsupportedEndpointError,
 )
+from .retry import retry_delay, should_retry
 
 
 def _is_keyless_envelope(body) -> bool:
@@ -54,7 +55,8 @@ class AsyncTavilyClient:
                  session_id: Optional[str] = None,
                  human_id: Optional[str] = None,
                  client_name: Optional[str] = None,
-                 client: Optional[httpx.AsyncClient] = None):
+                 client: Optional[httpx.AsyncClient] = None,
+                 max_retries: int = 0):
         if api_key is None:
             api_key = os.getenv("TAVILY_API_KEY")
 
@@ -68,6 +70,7 @@ class AsyncTavilyClient:
         self._api_base_url = api_base_url or "https://api.tavily.com"
         self._company_info_tags = company_info_tags
         self._keyless = api_key is None and client is None
+        self.max_retries = max(0, max_retries)
 
         if self._keyless:
             # Honor an explicit client_source so non-SDK keyless surfaces
@@ -175,6 +178,33 @@ class AsyncTavilyClient:
         if self._keyless:
             raise KeylessUnsupportedEndpointError(method)
 
+    async def _post_with_retry(self, url: str, payload: str, timeout: float, headers: Optional[dict] = None, retryable_statuses=None):
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        timeout_budget = timeout if timeout is not None else float("inf")
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await self._client.post(url, content=payload, timeout=timeout, **({"headers": headers} if headers else {}))
+            except httpx.TimeoutException:
+                raise TimeoutError(timeout)
+            except httpx.RequestError:
+                if retryable_statuses is not None or not should_retry(attempt, self.max_retries):
+                    raise
+                delay = retry_delay(attempt)
+                remaining = timeout_budget - (loop.time() - started_at)
+                if remaining <= 0:
+                    raise TimeoutError(timeout)
+                await asyncio.sleep(min(delay, remaining))
+                continue
+            if response.status_code == 200 or not should_retry(attempt, self.max_retries, response.status_code, retryable_statuses):
+                return response
+            delay = retry_delay(attempt, response.headers.get("Retry-After"))
+            remaining = timeout_budget - (loop.time() - started_at)
+            if remaining <= 0:
+                return response
+            await asyncio.sleep(min(delay, remaining))
+        return response
+
     @staticmethod
     def _pop_request_headers(kwargs: dict) -> Optional[dict]:
         """Pop project_id, session_id, human_id, and client_name from kwargs and return them as headers.
@@ -248,10 +278,7 @@ class AsyncTavilyClient:
 
         timeout = min(timeout, 120)
 
-        try:
-            response = await self._client.post("/search", content=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except httpx.TimeoutException:
-            raise TimeoutError(timeout)
+        response = await self._post_with_retry("/search", json.dumps(data), timeout, override_headers)
 
         if response.status_code == 200:
             return response.json()
@@ -347,10 +374,7 @@ class AsyncTavilyClient:
         if kwargs:
             data.update(kwargs)
 
-        try:
-            response = await self._client.post("/extract", content=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except httpx.TimeoutException:
-            raise TimeoutError(timeout)
+        response = await self._post_with_retry("/extract", json.dumps(data), timeout, override_headers)
 
         if response.status_code == 200:
             return response.json()
@@ -442,10 +466,7 @@ class AsyncTavilyClient:
 
         data = {k: v for k, v in data.items() if v is not None}
 
-        try:
-            response = await self._client.post("/crawl", content=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except httpx.TimeoutException:
-            raise TimeoutError(timeout)
+        response = await self._post_with_retry("/crawl", json.dumps(data), timeout, override_headers, {429})
 
         if response.status_code == 200:
             return response.json()
@@ -539,10 +560,7 @@ class AsyncTavilyClient:
 
         data = {k: v for k, v in data.items() if v is not None}
 
-        try:
-            response = await self._client.post("/map", content=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except httpx.TimeoutException:
-            raise TimeoutError(timeout)
+        response = await self._post_with_retry("/map", json.dumps(data), timeout, override_headers)
 
         if response.status_code == 200:
             return response.json()
@@ -757,10 +775,7 @@ class AsyncTavilyClient:
             return stream_generator()
         else:
             async def _make_request():
-                try:
-                    response = await self._client.post("/research", content=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-                except httpx.TimeoutException:
-                    raise TimeoutError(timeout)
+                response = await self._post_with_retry("/research", json.dumps(data), timeout, override_headers, {429})
 
                 if response.status_code == 200:
                     return response.json()

--- a/tavily/retry.py
+++ b/tavily/retry.py
@@ -1,0 +1,56 @@
+"""Shared retry policy helpers for the synchronous and asynchronous clients."""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Callable, Optional
+
+
+RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
+
+
+def parse_retry_after(value: Optional[str], now: Optional[datetime] = None) -> Optional[float]:
+    """Parse a Retry-After value expressed as seconds or an HTTP date."""
+    if not value:
+        return None
+
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        current = now or datetime.now(timezone.utc)
+        return max(0.0, (retry_at - current).total_seconds())
+    return max(0.0, seconds)
+
+
+def is_retryable_status(status_code: int) -> bool:
+    return status_code in RETRYABLE_STATUS_CODES
+
+
+def retry_delay(
+    attempt: int,
+    retry_after: Optional[str] = None,
+    *,
+    now: Optional[datetime] = None,
+    random_value: Optional[float] = None,
+    base_delay: float = 0.5,
+    max_delay: float = 30.0,
+) -> float:
+    """Return a bounded Retry-After delay or exponential full-jitter delay."""
+    server_delay = parse_retry_after(retry_after, now=now)
+    if server_delay is not None:
+        return min(server_delay, max_delay)
+
+    upper_bound = min(max_delay, base_delay * (2**attempt))
+    return (random_value if random_value is not None else random.random()) * upper_bound
+
+
+def should_retry(attempt: int, max_retries: int, status_code: Optional[int] = None) -> bool:
+    return attempt < max_retries and (status_code is None or is_retryable_status(status_code))

--- a/tavily/retry.py
+++ b/tavily/retry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import random
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import Callable, Optional
+from typing import Collection, Optional
 
 
 RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
@@ -52,5 +52,15 @@ def retry_delay(
     return (random_value if random_value is not None else random.random()) * upper_bound
 
 
-def should_retry(attempt: int, max_retries: int, status_code: Optional[int] = None) -> bool:
-    return attempt < max_retries and (status_code is None or is_retryable_status(status_code))
+def should_retry(
+    attempt: int,
+    max_retries: int,
+    status_code: Optional[int] = None,
+    retryable_statuses: Optional[Collection[int]] = None,
+) -> bool:
+    if attempt >= max_retries:
+        return False
+    if status_code is None:
+        return True
+    statuses = retryable_statuses or RETRYABLE_STATUS_CODES
+    return status_code in statuses

--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -2,6 +2,7 @@ import requests
 import json
 import os
 import warnings
+import time
 from typing import Literal, Sequence, Optional, List, Union, Generator
 from .utils import get_max_items_from_list
 from .errors import (
@@ -14,6 +15,7 @@ from .errors import (
     TavilyKeylessLimitError,
     KeylessUnsupportedEndpointError,
 )
+from .retry import retry_delay, should_retry
 
 
 def _is_keyless_envelope(body) -> bool:
@@ -54,6 +56,7 @@ class TavilyClient:
         human_id: Optional[str] = None,
         client_name: Optional[str] = None,
         session: Optional[requests.Session] = None,
+        max_retries: int = 0,
     ):
         if api_key is None:
             api_key = os.getenv("TAVILY_API_KEY")
@@ -73,6 +76,7 @@ class TavilyClient:
         self.api_key = api_key
         self._keyless = api_key is None and session is None
         self.proxies = resolved_proxies
+        self.max_retries = max(0, max_retries)
 
         if self._keyless:
             client_source_header = client_source or "tavily-python-keyless"
@@ -146,6 +150,36 @@ class TavilyClient:
         """Raise ``KeylessUnsupportedEndpointError`` when running in keyless mode."""
         if self._keyless:
             raise KeylessUnsupportedEndpointError(method)
+
+    def _post_with_retry(self, url: str, payload: str, timeout: float, headers: Optional[dict] = None, retryable_statuses=None):
+        started_at = time.monotonic()
+        timeout_budget = timeout if timeout is not None else float("inf")
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = self.session.post(
+                    url, data=payload, timeout=timeout, **({"headers": headers} if headers else {})
+                )
+            except requests.exceptions.Timeout:
+                raise TimeoutError(timeout)
+            except requests.exceptions.RequestException:
+                if retryable_statuses is not None or not should_retry(attempt, self.max_retries):
+                    raise
+                delay = retry_delay(attempt)
+                remaining = timeout_budget - (time.monotonic() - started_at)
+                if remaining <= 0:
+                    raise TimeoutError(timeout)
+                time.sleep(min(delay, remaining))
+                continue
+
+            if response.status_code == 200 or not should_retry(attempt, self.max_retries, response.status_code, retryable_statuses):
+                return response
+            delay = retry_delay(attempt, response.headers.get("Retry-After"))
+            remaining = timeout_budget - (time.monotonic() - started_at)
+            if remaining <= 0:
+                return response
+            time.sleep(min(delay, remaining))
+
+        return response
 
     @staticmethod
     def _pop_request_headers(kwargs: dict) -> Optional[dict]:
@@ -222,10 +256,7 @@ class TavilyClient:
         url = self.base_url + "/search"
         payload = json.dumps(data)
 
-        try:
-            response = self.session.post(url, data=payload, timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except requests.exceptions.Timeout:
-            raise TimeoutError(timeout)
+        response = self._post_with_retry(url, payload, timeout, override_headers)
 
         if response.status_code == 200:
             return response.json()
@@ -315,10 +346,7 @@ class TavilyClient:
         if kwargs:
             data.update(kwargs)
 
-        try:
-            response = self.session.post(self.base_url + "/extract", data=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except requests.exceptions.Timeout:
-            raise TimeoutError(timeout)
+        response = self._post_with_retry(self.base_url + "/extract", json.dumps(data), timeout, override_headers)
 
         if response.status_code == 200:
             return response.json()
@@ -404,10 +432,7 @@ class TavilyClient:
 
         data = {k: v for k, v in data.items() if v is not None}
 
-        try:
-            response = self.session.post(self.base_url + "/crawl", data=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except requests.exceptions.Timeout:
-            raise TimeoutError(timeout)
+        response = self._post_with_retry(self.base_url + "/crawl", json.dumps(data), timeout, override_headers, {429})
 
         if response.status_code == 200:
             return response.json()
@@ -499,10 +524,7 @@ class TavilyClient:
 
         data = {k: v for k, v in data.items() if v is not None}
 
-        try:
-            response = self.session.post(self.base_url + "/map", data=json.dumps(data), timeout=timeout, **({"headers": override_headers} if override_headers else {}))
-        except requests.exceptions.Timeout:
-            raise TimeoutError(timeout)
+        response = self._post_with_retry(self.base_url + "/map", json.dumps(data), timeout, override_headers)
 
         if response.status_code == 200:
             return response.json()
@@ -678,15 +700,9 @@ class TavilyClient:
 
             return stream_generator()
         else:
-            try:
-                response = self.session.post(
-                    self.base_url + "/research",
-                    data=json.dumps(data),
-                    timeout=timeout,
-                    **({"headers": override_headers} if override_headers else {})
-                )
-            except requests.exceptions.Timeout:
-                raise TimeoutError(timeout)
+            response = self._post_with_retry(
+                self.base_url + "/research", json.dumps(data), timeout, override_headers, {429}
+            )
 
             if response.status_code == 200:
                 return response.json()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timezone
+
+from tavily.retry import is_retryable_status, parse_retry_after, retry_delay, should_retry
+
+
+def test_parse_retry_after_seconds_and_invalid_values():
+    assert parse_retry_after("3") == 3
+    assert parse_retry_after("invalid") is None
+    assert parse_retry_after(None) is None
+
+
+def test_parse_retry_after_http_date():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert parse_retry_after("Thu, 01 Jan 2026 00:00:03 GMT", now=now) == 3
+
+
+def test_retry_delay_prefers_server_value_and_caps_it():
+    assert retry_delay(0, "45", max_delay=30) == 30
+    assert retry_delay(2, random_value=0.5, base_delay=1) == 2
+
+
+def test_retry_policy_limits_attempts_and_statuses():
+    assert is_retryable_status(429)
+    assert is_retryable_status(503)
+    assert not is_retryable_status(400)
+    assert should_retry(0, 1, 429)
+    assert not should_retry(1, 1, 429)
+    assert not should_retry(0, 1, 400)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -7,6 +7,7 @@ def test_parse_retry_after_seconds_and_invalid_values():
     assert parse_retry_after("3") == 3
     assert parse_retry_after("invalid") is None
     assert parse_retry_after(None) is None
+    assert parse_retry_after("-1") == 0
 
 
 def test_parse_retry_after_http_date():
@@ -26,3 +27,5 @@ def test_retry_policy_limits_attempts_and_statuses():
     assert should_retry(0, 1, 429)
     assert not should_retry(1, 1, 429)
     assert not should_retry(0, 1, 400)
+    assert should_retry(0, 1, 429, {429})
+    assert not should_retry(0, 1, 503, {429})


### PR DESCRIPTION
## Summary
- add shared, deterministic retry policy helpers for integer and HTTP-date `Retry-After` values
- add opt-in `max_retries=0` support to sync and async clients
- retry safe endpoints for transient statuses and connection errors
- restrict crawl and non-stream research retries to HTTP 429 to avoid duplicate jobs
- leave streaming research behavior unchanged
- bound retry sleeps by the request timeout budget

Closes #177

## Tests
- `python -m pytest -q` — 102 passed
- `python -m compileall -q tavily`
- `git diff --check`

No API keys, GPU, model downloads, or external services are required.