### PR TITLE
fix: enforce include_domains on search results

### DIFF
--- a/tavily/async_tavily.py
+++ b/tavily/async_tavily.py
@@ -5,7 +5,7 @@ from typing import Literal, Sequence, Optional, List, Union, AsyncGenerator, Awa
 
 import httpx
 
-from .utils import get_max_items_from_list
+from .utils import filter_results_by_domains, get_max_items_from_list
 from .errors import (
     UsageLimitExceededError,
     InvalidAPIKeyError,
@@ -308,7 +308,7 @@ class AsyncTavilyClient:
 
         tavily_results = response_dict.get("results", [])
 
-        response_dict["results"] = tavily_results
+        response_dict["results"] = filter_results_by_domains(tavily_results, include_domains)
 
         return response_dict
 

--- a/tavily/tavily.py
+++ b/tavily/tavily.py
@@ -3,7 +3,7 @@ import json
 import os
 import warnings
 from typing import Literal, Sequence, Optional, List, Union, Generator
-from .utils import get_max_items_from_list
+from .utils import filter_results_by_domains, get_max_items_from_list
 from .errors import (
     UsageLimitExceededError,
     InvalidAPIKeyError,
@@ -280,6 +280,7 @@ class TavilyClient:
                                      exact_match=exact_match,
                                      **kwargs)
         response_dict.setdefault("results", [])
+        response_dict["results"] = filter_results_by_domains(response_dict["results"], include_domains)
         return response_dict
 
     def _extract(self,

--- a/tavily/utils.py
+++ b/tavily/utils.py
@@ -1,6 +1,7 @@
 import tiktoken
 import json
-from typing import Sequence, List, Dict
+from urllib.parse import urlparse
+from typing import Sequence, List, Dict, Optional
 from .config import DEFAULT_MODEL_ENCODING, DEFAULT_MAX_TOKENS
 
 
@@ -27,3 +28,35 @@ def get_max_items_from_list(data: Sequence[dict], max_tokens: int = DEFAULT_MAX_
             result.append(item)
             current_tokens = new_total_tokens
     return result
+
+
+def filter_results_by_domains(
+    results: Sequence[dict], include_domains: Optional[Sequence[str]] = None
+) -> List[dict]:
+    """Keep only results whose host matches an included domain or its subdomain."""
+    if not include_domains:
+        return list(results)
+
+    domains = {
+        domain.strip().lower().rstrip(".")
+        for domain in include_domains
+        if isinstance(domain, str) and domain.strip()
+    }
+    if not domains:
+        return list(results)
+
+    filtered_results = []
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        try:
+            hostname = urlparse(result.get("url", "")).hostname
+        except (TypeError, ValueError):
+            continue
+        if hostname is None:
+            continue
+        hostname = hostname.lower().rstrip(".")
+        if any(hostname == domain or hostname.endswith(f".{domain}") for domain in domains):
+            filtered_results.append(result)
+
+    return filtered_results

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -26,7 +26,7 @@ def validate_default(request, response):
     assert request.json().get('query') == "What is Tavily?"
     assert response == dummy_response
 
-def validate_specific(request, response):
+def validate_specific(request, response, expected_response=dummy_response):
     assert request.method == "POST"
     assert request.url == "https://api.tavily.com/search"
     assert request.headers["Authorization"] == "Bearer tvly-test"
@@ -49,7 +49,7 @@ def validate_specific(request, response):
     }.items():
         assert request_json.get(key) == value
 
-    assert response == dummy_response
+    assert response == expected_response
 
 def test_sync_search_defaults(sync_interceptor, sync_client):
     sync_interceptor.set_response(200, json=dummy_response)
@@ -58,7 +58,17 @@ def test_sync_search_defaults(sync_interceptor, sync_client):
     validate_default(request, response)
 
 def test_sync_search_specific(sync_interceptor, sync_client):
-    sync_interceptor.set_response(200, json=dummy_response)
+    response_with_out_of_scope_results = {
+        **dummy_response,
+        "results": [
+            {"url": "https://tavily.com/allowed", "title": "Root domain"},
+            {"url": "https://docs.tavily.com/allowed", "title": "Subdomain"},
+            {"url": "https://example.com/outside", "title": "Outside domain"},
+            {"url": "https://not-tavily.com/outside", "title": "Similar suffix"},
+            {"url": "not a URL", "title": "Malformed URL"},
+        ],
+    }
+    sync_interceptor.set_response(200, json=response_with_out_of_scope_results)
     response = sync_client.search(
         "What is Tavily?",
         search_depth="advanced",
@@ -75,7 +85,12 @@ def test_sync_search_specific(sync_interceptor, sync_client):
     )
 
     request = sync_interceptor.get_request()
-    validate_specific(request, response)
+    expected_response = {
+        **response_with_out_of_scope_results,
+        "results": response_with_out_of_scope_results["results"][:2],
+    }
+    validate_specific(request, response, expected_response)
+    assert [result["title"] for result in response["results"]] == ["Root domain", "Subdomain"]
 
 def test_async_search_defaults(async_interceptor, async_client):
     async_interceptor.set_response(200, json=dummy_response)
@@ -84,7 +99,17 @@ def test_async_search_defaults(async_interceptor, async_client):
     validate_default(request, response)
 
 def test_async_search_specific(async_interceptor, async_client):
-    async_interceptor.set_response(200, json=dummy_response)
+    response_with_out_of_scope_results = {
+        **dummy_response,
+        "results": [
+            {"url": "https://tavily.com/allowed", "title": "Root domain"},
+            {"url": "https://docs.tavily.com/allowed", "title": "Subdomain"},
+            {"url": "https://example.com/outside", "title": "Outside domain"},
+            {"url": "https://not-tavily.com/outside", "title": "Similar suffix"},
+            {"url": "not a URL", "title": "Malformed URL"},
+        ],
+    }
+    async_interceptor.set_response(200, json=response_with_out_of_scope_results)
     response = asyncio.run(async_client.search(
         "What is Tavily?",
         search_depth="advanced",
@@ -101,7 +126,27 @@ def test_async_search_specific(async_interceptor, async_client):
     ))
 
     request = async_interceptor.get_request()
-    validate_specific(request, response)
+    expected_response = {
+        **response_with_out_of_scope_results,
+        "results": response_with_out_of_scope_results["results"][:2],
+    }
+    validate_specific(request, response, expected_response)
+    assert [result["title"] for result in response["results"]] == ["Root domain", "Subdomain"]
+
+
+def test_sync_search_without_domain_filter_preserves_results(sync_interceptor, sync_client):
+    response_with_out_of_scope_results = {
+        **dummy_response,
+        "results": [
+            {"url": "https://tavily.com/allowed", "title": "Allowed"},
+            {"url": "https://example.com/outside", "title": "Outside"},
+        ],
+    }
+    sync_interceptor.set_response(200, json=response_with_out_of_scope_results)
+
+    response = sync_client.search("What is Tavily?")
+
+    assert response["results"] == response_with_out_of_scope_results["results"]
 
 def test_sync_search_exact_match_not_sent_by_default(sync_interceptor, sync_client):
     sync_interceptor.set_response(200, json=dummy_response)


### PR DESCRIPTION
Fixes #173. Filter sync and async search results by parsed hostname after the API response, preserving exact domains and subdomains while rejecting out-of-scope and malformed URLs. Added mocked regression coverage for domain boundaries and no-filter behavior. Tests: python -m pytest -o addopts= -q (99 passed).